### PR TITLE
unify the trace functions of numerical and analytical fields

### DIFF
--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -74,14 +74,14 @@ end
 Return a tuple consists of particle charge, mass for a prescribed `species` and interpolated
 EM field functions.
 """
-function prepare(grid::CartesianGrid, E, B; species::Species=Proton, q=1.0, m=1.0)
+function prepare(grid::CartesianGrid, E::TE, B::TB; species::Species=Proton, q=1.0, m=1.0) where {TE, TB}
 
    q, m = getchargemass(species, q, m)
 
    gridx, gridy, gridz = makegrid(grid)
 
-   E = getinterp(E, gridx, gridy, gridz)
-   B = getinterp(B, gridx, gridy, gridz)
+   E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz) : E
+   B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz) : B
 
    q, m, E, B
 end
@@ -92,15 +92,15 @@ end
 Return a tuple consists of particle charge, mass for a prescribed `species` of charge `q`
 and mass `m`, analytic EM field functions, and external force `F`.
 """
-function prepare(grid::CartesianGrid, E, B, F; species::Species=Proton, q=1.0, m=1.0)
+function prepare(grid::CartesianGrid, E::TE, B::TB, F::TF; species::Species=Proton, q=1.0, m=1.0) where {TE, TB, TF}
 
    q, m = getchargemass(species, q, m)
 
    gridx, gridy, gridz = makegrid(grid)
 
-   E = getinterp(E, gridx, gridy, gridz)
-   B = getinterp(B, gridx, gridy, gridz)
-   F = getinterp(F, gridx, gridy, gridz)
+   E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz) : E
+   B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz) : B
+   F = TF <: AbstractArray ? getinterp(F, gridx, gridy, gridz) : F
 
    q, m, E, B, F
 end

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -5,8 +5,8 @@ using Meshes
 using Interpolations
 using StaticArrays
 
-export prepare, trace_numeric!, trace_analytic!, trace_analytic_relativistic!
-export trace_numeric, trace_analytic, trace_analytic_relativistic
+export prepare, trace!, trace_relativistic!
+export trace, trace_relativistic
 export Proton, Electron, Ion, User
 
 include("utility/utility.jl")
@@ -58,7 +58,14 @@ function getinterp(A, gridx, gridy, gridz)
    itp = extrapolate(interpolate(Az, BSpline(Cubic(Interpolations.Line(OnGrid())))), NaN)
    interpz = scale(itp, gridx, gridy, gridz)
 
-   interpx, interpy, interpz
+   # Return field value at a given location.
+   function get_field(xu)
+      r = @view xu[1:3]
+
+      return SA[interpx(r...), interpy(r...), interpz(r...)]
+   end
+
+   return get_field
 end
 
 """
@@ -73,10 +80,10 @@ function prepare(grid::CartesianGrid, E, B; species::Species=Proton, q=1.0, m=1.
 
    gridx, gridy, gridz = makegrid(grid)
 
-   interpEx, interpEy, interpEz = getinterp(E, gridx, gridy, gridz)
-   interpBx, interpBy, interpBz = getinterp(B, gridx, gridy, gridz)
+   E = getinterp(E, gridx, gridy, gridz)
+   B = getinterp(B, gridx, gridy, gridz)
 
-   q, m, (interpEx, interpEy, interpEz), (interpBx, interpBy, interpBz)
+   q, m, E, B
 end
 
 """
@@ -91,12 +98,11 @@ function prepare(grid::CartesianGrid, E, B, F; species::Species=Proton, q=1.0, m
 
    gridx, gridy, gridz = makegrid(grid)
 
-   interpEx, interpEy, interpEz = getinterp(E, gridx, gridy, gridz)
-   interpBx, interpBy, interpBz = getinterp(B, gridx, gridy, gridz)
-   interpFx, interpFy, interpFz = getinterp(F, gridx, gridy, gridz)
+   E = getinterp(E, gridx, gridy, gridz)
+   B = getinterp(B, gridx, gridy, gridz)
+   F = getinterp(F, gridx, gridy, gridz)
 
-   q, m, (interpEx, interpEy, interpEz), (interpBx, interpBy, interpBz),
-   (interpFx, interpFy, interpFz)
+   q, m, E, B, F
 end
 
 """
@@ -125,88 +131,37 @@ function prepare(E, B, F; species::Species=Proton, q=1.0, m=1.0)
    t
 end
 
-"ODE equations for charged particle moving in static numerical EM field."
-function trace_numeric!(dy, y, p, t)
-   q, m, interpE, interpB = p
-   dy[1:3] = y[4:6]
-   dy[4:6] = q/m*(getE(y, interpE) + y[4:6] × getB(y, interpB))
-end
-
-function trace_numeric(y, p, t)
-   q, m, interpE, interpB = p
-   dx, dy, dz = y[4:6]
-   dux, duy, duz = q/m*(getE(y, interpE) + y[4:6] × getB(y, interpB))
-   SVector{6}(dx, dy, dz, dux, duy, duz)
-end
-
-"ODE equations for charged particle moving in static numerical EM field and
-external force field."
-function trace_numeric_full!(dy, y, p, t)
-   q, m, interpE, interpB, interpF = p
-   dy[1:3] = y[4:6]
-   dy[4:6] = (q*(getE(y, interpE) + y[4:6] × getB(y, interpB)) + getF(t, interpF)) / m
-end
-
-function trace_numeric_full(y, p, t)
-   q, m, interpE, interpB, interpF = p
-   dx, dy, dz = y[4:6]
-   dux, duy, duz = (q*(getE(y, interpE) + y[4:6] × getB(y, interpB)) + getF(t, interpF)) / m
-   SVector{6}(dx, dy, dz, dux, duy, duz)
-end
-
-"ODE equations for relativistic charged particle moving in static numerical EM field."
-function trace_numeric_relativistic!(dy, y, p, t)
-   q, m, interpE, interpB = p
-   if y[4]*y[4] + y[5]*y[5] + y[6]*y[6] ≥ c^2
-      throw(ArgumentError("Particle faster than the speed of light!"))
-   end
-   γInv = √(1.0 - (y[4]*y[4] + y[5]*y[5] + y[6]*y[6])/c^2)
-   dy[1:3] = y[4:6]
-   dy[4:6] = q/m*γInv*(getE(y, interpE) + y[4:6] × getB(y, interpB))
-end
-
-function trace_numeric_relativistic(y, p, t)
-   q, m, interpE, interpB = p
-   if y[4]*y[4] + y[5]*y[5] + y[6]*y[6] ≥ c^2
-      throw(ArgumentError("Particle faster than the speed of light!"))
-   end
-   γInv = √(1.0 - (y[4]*y[4] + y[5]*y[5] + y[6]*y[6])/c^2)
-   dx, dy, dz = y[4:6]
-   dux, duy, duz = q/m*γInv*(getE(y, interpE) + y[4:6] × getB(y, interpB))
-   SVector{6}(dx, dy, dz, dux, duy, duz)
-end
-
-"ODE equations for charged particle moving in static analytical EM field."
-function trace_analytic!(dy, y, p, t)
+"ODE equations for charged particle moving in static EM field."
+function trace!(dy, y, p, t)
    q, m, E, B = p
    dy[1:3] = y[4:6]
    dy[4:6] = q/m*(E(y) + y[4:6] × (B(y[1:3])))
 end
 
-function trace_analytic(y, p, t)
+function trace(y, p, t)
    q, m, E, B = p
    dx, dy, dz = y[4:6]
    dux, duy, duz = q/m*(E(y) + y[4:6] × (B(y[1:3])))
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
 
-"ODE equations for charged particle moving in static analytical EM field and external force
+"ODE equations for charged particle moving in static EM field and external force
 field."
-function trace_analytic_full!(dy, y, p, t)
+function trace_full!(dy, y, p, t)
    q, m, E, B, F = p
    dy[1:3] = y[4:6]
    dy[4:6] = (q*(E(y) + y[4:6] × (B(y[1:3]))) + F) / m
 end
 
-function trace_analytic_full(y, p, t)
+function trace_full(y, p, t)
    q, m, E, B, F = p
    dx, dy, dz = y[4:6]
    dux, duy, duz = (q*(E(y) + y[4:6] × (B(y[1:3]))) + F) / m
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
 
-"ODE equations for relativistic charged particle moving in static analytical EM field."
-function trace_analytic_relativistic!(dy, y, p, t)
+"ODE equations for relativistic charged particle moving in static EM field."
+function trace_relativistic!(dy, y, p, t)
    q, m, E, B = p
 
    if y[4]*y[4] + y[5]*y[5] + y[6]*y[6] ≥ c^2
@@ -217,7 +172,7 @@ function trace_analytic_relativistic!(dy, y, p, t)
    dy[4:6] = q/m*γInv*(E(y) + y[4:6] × (B(y[1:3])))
 end
 
-function trace_analytic_relativistic(y, p, t)
+function trace_relativistic(y, p, t)
    q, m, E, B = p
 
    if y[4]*y[4] + y[5]*y[5] + y[6]*y[6] ≥ c^2
@@ -227,30 +182,6 @@ function trace_analytic_relativistic(y, p, t)
    dx, dy, dz = y[4:6]
    dux, duy, duz = q/m*γInv*(E(y) + y[4:6] × (B(y[1:3])))
    SVector{6}(dx, dy, dz, dux, duy, duz)
-end
-
-# Return eletric field at a given location.
-function getE(xu, interpE)
-   x = @view xu[1:3]
-   u = @view xu[4:6]
-
-   SA[interpE[1](x...), interpE[2](x...), interpE[3](x...)]
-end
-
-# Return magnetic field at a given location.
-function getB(xu, interpB)
-   x = @view xu[1:3]
-   u = @view xu[4:6]
-
-   SA[interpB[1](x...), interpB[2](x...), interpB[3](x...)]
-end
-
-# Return force at a given location.
-function getF(xu, interpF)
-   x = @view xu[1:3]
-   u = @view xu[4:6]
-
-   SA[interpF[1](x...), interpF[2](x...), interpF[3](x...)]
 end
 
 end

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -5,8 +5,8 @@ using Meshes
 using Interpolations
 using StaticArrays
 
-export prepare, trace!, trace_relativistic!
-export trace, trace_relativistic
+export prepare, trace!, trace_relativistic!, trace_full!
+export trace, trace_relativistic, trace_full
 export Proton, Electron, Ion, User
 
 include("utility/utility.jl")
@@ -144,13 +144,13 @@ field."
 function trace_full!(dy, y, p, t)
    q, m, E, B, F = p
    dy[1:3] = y[4:6]
-   dy[4:6] = (q*(E(y) + y[4:6] × (B(y[1:3]))) + F) / m
+   dy[4:6] = (q*(E(y) + y[4:6] × (B(y[1:3]))) + F(y)) / m
 end
 
 function trace_full(y, p, t)
    q, m, E, B, F = p
    dx, dy, dz = y[4:6]
-   dux, duy, duz = (q*(E(y) + y[4:6] × (B(y[1:3]))) + F) / m
+   dux, duy, duz = (q*(E(y) + y[4:6] × (B(y[1:3]))) + F(y)) / m
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
 

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -17,7 +17,6 @@ Type for the particles, `Proton`, `Electron`, `Ion`, or `User`.
 @enum Species Proton Electron Ion User
 
 function getchargemass(species::Species, q, m)
-
    if species == Proton
       q = qᵢ
       m = mᵢ
@@ -29,7 +28,6 @@ function getchargemass(species::Species, q, m)
 end
 
 function makegrid(grid)
-
    gridmin = coordinates(minimum(grid))
    gridmax = coordinates(maximum(grid))
    Δx = spacing(grid)
@@ -42,7 +40,6 @@ function makegrid(grid)
 end
 
 function getinterp(A, gridx, gridy, gridz)
-
    @assert size(A,1) == 3 && ndims(A) == 4 "Only support 3D force field!"
 
    Ax = @view A[1,:,:,:]
@@ -75,7 +72,6 @@ Return a tuple consists of particle charge, mass for a prescribed `species` and 
 EM field functions.
 """
 function prepare(grid::CartesianGrid, E::TE, B::TB; species::Species=Proton, q=1.0, m=1.0) where {TE, TB}
-
    q, m = getchargemass(species, q, m)
 
    gridx, gridy, gridz = makegrid(grid)
@@ -93,7 +89,6 @@ Return a tuple consists of particle charge, mass for a prescribed `species` of c
 and mass `m`, analytic EM field functions, and external force `F`.
 """
 function prepare(grid::CartesianGrid, E::TE, B::TB, F::TF; species::Species=Proton, q=1.0, m=1.0) where {TE, TB, TF}
-
    q, m = getchargemass(species, q, m)
 
    gridx, gridy, gridz = makegrid(grid)
@@ -113,7 +108,6 @@ and mass `m` and analytic EM field functions. Prescribed `species` are `Electron
 `Proton`; other species can be manually specified with `species=Ion/User`, `q` and `m`.
 """
 function prepare(E, B; species::Species=Proton, q=1.0, m=1.0)
-
    q, m = getchargemass(species, q, m)
 
    q, m, E, B
@@ -183,5 +177,4 @@ function trace_relativistic(y, p, t)
    dux, duy, duz = q/m*γInv*(E(y) + y[4:6] × (B(y[1:3])))
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,4 +108,39 @@ end
       @test x[306] ≈ 1.2588844644203672e7 rtol=1e-6
 
    end
+
+   @testset "mixed fields" begin
+      x = range(-10, 10, length=15)
+      y = range(-10, 10, length=20)
+      z = range(-10, 10, length=25)
+      B = fill(0.0, 3, length(x), length(y), length(z)) # [T]
+
+      B[3,:,:,:] .= 10e-9
+      E_field(r) = SA[0, 0, 5e-10]
+
+      Δx = x[2] - x[1]
+      Δy = y[2] - y[1]
+      Δz = z[2] - z[1]
+
+      mesh = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
+         (x[1], y[1], z[1]),
+         (Δx, Δy, Δz))
+
+      x0 = [0.0, 0.0, 0.0] # initial position, [m]
+      u0 = [1.0, 0.0, 0.0] # initial velocity, [m/s]
+      stateinit = [x0..., u0...]
+
+      param = prepare(mesh, E_field, B)
+      tspan = (0.0, 1.0)
+
+      prob = ODEProblem(trace!, stateinit, tspan, param)
+
+      sol = solve(prob, Tsit5(); save_idxs=[1,2,3])
+
+      x = getindex.(sol.u, 1)
+      y = getindex.(sol.u, 2)
+      z = getindex.(sol.u, 3)
+
+      @test length(x) == 8 && x[end] ≈ 0.8540967226885379
+   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,6 @@ end
 
       param = prepare(mesh, E, B)
       tspan = (0.0, 1.0)
-      trace! = trace_numeric!
 
       prob = ODEProblem(trace!, stateinit, tspan, param)
 
@@ -59,7 +58,6 @@ end
 
       param = prepare(mesh, E, B)
       tspan = (0.0, 1.0)
-      trace = trace_numeric
 
       prob = ODEProblem(trace, stateinit, tspan, param)
 
@@ -90,7 +88,6 @@ end
       param = prepare(TestParticle.getE_dipole, TestParticle.getB_dipole)
       tspan = (0.0, 1.0)
       
-      trace! = trace_analytic!
       prob = ODEProblem(trace!, stateinit, tspan, param)
 
       sol = solve(prob, Tsit5(); save_idxs=[1,2,3])
@@ -102,7 +99,6 @@ end
       # static array version (results not identical with above: maybe some bugs?)
       stateinit = SA[r₀..., v₀...]
 
-      trace = trace_analytic
       prob = ODEProblem(trace, stateinit, tspan, param)
 
       sol = solve(prob, Tsit5(); save_idxs=[1,2,3])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,7 +109,7 @@ end
 
    end
 
-   @testset "mixed fields" begin
+   @testset "mixed type fields" begin
       x = range(-10, 10, length=15)
       y = range(-10, 10, length=20)
       z = range(-10, 10, length=25)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,9 +114,12 @@ end
       y = range(-10, 10, length=20)
       z = range(-10, 10, length=25)
       B = fill(0.0, 3, length(x), length(y), length(z)) # [T]
+      F = fill(0.0, 3, length(x), length(y), length(z)) # [N]
 
-      B[3,:,:,:] .= 10e-9
-      E_field(r) = SA[0, 0, 5e-10]
+      B[3,:,:,:] .= 1e-11
+      E_field(r) = SA[0, 5e-11, 0]  # [V/M]
+      F[1,:,:,:] .= 9.10938356e-42
+
 
       Δx = x[2] - x[1]
       Δy = y[2] - y[1]
@@ -127,13 +130,13 @@ end
          (Δx, Δy, Δz))
 
       x0 = [0.0, 0.0, 0.0] # initial position, [m]
-      u0 = [1.0, 0.0, 0.0] # initial velocity, [m/s]
+      u0 = [0.0, 1.0, 0.0] # initial velocity, [m/s]
       stateinit = [x0..., u0...]
 
-      param = prepare(mesh, E_field, B)
+      param = prepare(mesh, E_field, B, F; species=Electron)
       tspan = (0.0, 1.0)
 
-      prob = ODEProblem(trace!, stateinit, tspan, param)
+      prob = ODEProblem(trace_full!, stateinit, tspan, param)
 
       sol = solve(prob, Tsit5(); save_idxs=[1,2,3])
 
@@ -141,6 +144,6 @@ end
       y = getindex.(sol.u, 2)
       z = getindex.(sol.u, 3)
 
-      @test length(x) == 8 && x[end] ≈ 0.8540967226885379
+      @test x[end] ≈ 1.5324506965560782 && y[end] ≈ -2.8156470047903706
    end
 end


### PR DESCRIPTION
1. I have modified the getinterp function to a closure function to return a field function which is similar to analytical field. Meanwhile, those redundant functions were deleted.
2. Fixing the function names in the test sets.
3. Adding a type judgement to prepare function for supporting the mixture of different type of fields.
4. Adding a simple test set about mixed fields.