### PR TITLE
add support for time-dependent fields and unify the interfaces of `trace` and `trace_full`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
       - name: Run benchmarks
-        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge(;baseline=nothing, retune=true)'
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge(; retune=true)'
       - name: Post results
         run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
         env:

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -9,6 +9,7 @@ const SUITE = BenchmarkGroup()
 SUITE["trace"] = BenchmarkGroup()
 SUITE["trace"]["analytic field"] = BenchmarkGroup()
 SUITE["trace"]["numerical field"] = BenchmarkGroup()
+SUITE["trace"]["time-dependent field"] = BenchmarkGroup()
 
 # analytic field
 E_analytic(xu) = SA[5e-10, 5e-10, 0]
@@ -23,6 +24,10 @@ E_numeric = fill(0.0, 3, length(x), length(y), length(z)) # [V/m]
 B_numeric[3,:,:,:] .= 10e-9
 E_numeric[1,:,:,:] .= 5e-10
 E_numeric[2,:,:,:] .= 5e-10
+B_td(xu, t) = SA[0, 0, 1e-11*cos(2π*t)]
+E_td(xu, t) = SA[5e-11*sin(2π*t), 0, 0]
+F_td(xu) = SA[0, 9.10938356e-42, 0]
+
 Δx = x[2] - x[1]
 Δy = y[2] - y[1]
 Δz = z[2] - z[1]
@@ -47,3 +52,9 @@ prob_ip = ODEProblem(trace!, stateinit, tspan, param_numeric) # in place
 prob_oop = ODEProblem(trace, SA[stateinit...], tspan, param_numeric) # out of place
 SUITE["trace"]["numerical field"]["in place"] = @benchmarkable solve($prob_ip, Tsit5(); save_idxs=[1,2,3])
 SUITE["trace"]["numerical field"]["out of place"] = @benchmarkable solve($prob_oop, Tsit5(); save_idxs=[1,2,3])
+
+param_td = prepare(E_td, B_td, F_td)
+prob_ip = ODEProblem(trace!, stateinit, tspan, param_td) # in place
+prob_oop = ODEProblem(trace, SA[stateinit...], tspan, param_td) # out of place
+SUITE["trace"]["time-dependent field"]["in place"] = @benchmarkable solve($prob_ip, Tsit5(); save_idxs=[1,2,3])
+SUITE["trace"]["time-dependent field"]["out of place"] = @benchmarkable solve($prob_oop, Tsit5(); save_idxs=[1,2,3])

--- a/benchmark/runbench.jl
+++ b/benchmark/runbench.jl
@@ -3,5 +3,7 @@
 using PkgBenchmark
 
 current = BenchmarkConfig(juliacmd = `julia -O3`)
-result = benchmarkpkg("TestParticle", current; retune=true)
+baseline = BenchmarkConfig(id = "master", juliacmd = `julia -O3`)
+# result = benchmarkpkg("TestParticle", current; retune=true)
+result = judge("TestParticle", current, baseline; retune=true)
 export_markdown("report.md", result)

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -166,14 +166,16 @@ end
 "ODE equations for charged particle moving in static EM field."
 function trace!(dy, y, p::TPTuple, t)
    q, m, E, B = p
-   dy[1:3] = y[4:6]
-   dy[4:6] = q/m*(E(y, t) + y[4:6] × (B(y, t)))
+   v = @view y[4:6]
+   dy[1:3] = v
+   dy[4:6] = q/m*(E(y, t) + v × (B(y, t)))
 end
 
 function trace(y, p::TPTuple, t)
    q, m, E, B = p
-   dx, dy, dz = y[4:6]
-   dux, duy, duz = q/m*(E(y, t) + y[4:6] × (B(y, t)))
+   v = @view y[4:6]
+   dx, dy, dz = v
+   dux, duy, duz = q/m*(E(y, t) + v × (B(y, t)))
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
 
@@ -181,14 +183,16 @@ end
 field."
 function trace!(dy, y, p::FullTPTuple, t)
    q, m, E, B, F = p
-   dy[1:3] = y[4:6]
-   dy[4:6] = (q*(E(y, t) + y[4:6] × (B(y, t))) + F(y, t)) / m
+   v = @view y[4:6]
+   dy[1:3] = v
+   dy[4:6] = (q*(E(y, t) + v × (B(y, t))) + F(y, t)) / m
 end
 
 function trace(y, p::FullTPTuple, t)
    q, m, E, B, F = p
-   dx, dy, dz = y[4:6]
-   dux, duy, duz = (q*(E(y, t) + y[4:6] × (B(y, t))) + F(y, t)) / m
+   v = @view y[4:6]
+   dx, dy, dz = v
+   dux, duy, duz = (q*(E(y, t) + v × (B(y, t))) + F(y, t)) / m
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
 
@@ -200,8 +204,9 @@ function trace_relativistic!(dy, y, p::TPTuple, t)
       throw(ArgumentError("Particle faster than the speed of light!"))
    end
    γInv = √(1.0 - (y[4]*y[4] + y[5]*y[5] + y[6]*y[6])/c^2)
-   dy[1:3] = y[4:6]
-   dy[4:6] = q/m*γInv*(E(y, t) + y[4:6] × (B(y, t)))
+   v = @view y[4:6]
+   dy[1:3] = v
+   dy[4:6] = q/m*γInv*(E(y, t) + v × (B(y, t)))
 end
 
 function trace_relativistic(y, p::TPTuple, t)
@@ -211,8 +216,9 @@ function trace_relativistic(y, p::TPTuple, t)
       throw(ArgumentError("Particle faster than the speed of light!"))
    end
    γInv = √(1.0 - (y[4]*y[4] + y[5]*y[5] + y[6]*y[6])/c^2)
-   dx, dy, dz = y[4:6]
-   dux, duy, duz = q/m*γInv*(E(y, t) + y[4:6] × (B(y, t)))
+   v = @view y[4:6]
+   dx, dy, dz = v
+   dux, duy, duz = q/m*γInv*(E(y, t) + v × (B(y, t)))
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
 end

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -87,22 +87,22 @@ abstract type AbstractField{itd} end
 """
     Field{itd, F} <: AbstractField{itd}
 
-A presentation of a field function `f`, defined by:
+A representation of a field function `f`, defined by:
 
-time independent field
+time-independent field
 ```math
 \\mathbf{F} = F(\\mathbf{x}),
 ```
 
-time dependent field
+time-dependent field
 ```math
 \\mathbf{F} = F(\\mathbf{x}, t).
 ```
 
 # Arguments
-- `field_function::Function`: The function of field.
-- `itd::Bool`: istimedependent, whether the field function is time dependent.
-- `F`: The type of field_function.
+- `field_function::Function`: the function of field.
+- `itd::Bool`: whether the field function is time dependent.
+- `F`: the type of `field_function`.
 """
 struct Field{itd, F} <: AbstractField{itd}
    field_function::F

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -85,6 +85,7 @@ abstract type AbstractField{itd} end
 
 struct Field{itd, F} <: AbstractField{itd}
    field_function::F
+   Field{itd, F}(field_function::F) where {itd, F} = isa(itd, Bool) ? new(field_function) : throw(ArgumentError("itd must be a boolean."))
 end
 
 Field(f::Function) = Field{is_time_dependent(f), typeof(f)}(f)

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -62,8 +62,37 @@ function getinterp(A, gridx, gridy, gridz)
       return SA[interpx(r...), interpy(r...), interpz(r...)]
    end
 
-   return get_field
+   return Field(get_field)
 end
+
+function is_time_dependent(f)
+   itp_param_number = 2
+   numargs = [length(m.sig.parameters)-1 for m in methods(f)]
+   itp = any(x -> x == itp_param_number, numargs)
+   if !itp
+      if any(x -> x == itp_param_number-1, numargs)
+         return false
+      else
+         name = nameof(f)
+         throw(ArgumentError("All methods for the field function $name had too many arguments."))
+      end
+   else
+      return true
+   end
+end
+
+abstract type AbstractField{itd} end
+
+struct Field{itd, F} <: AbstractField{itd}
+   field_function::F
+end
+
+Field(f::Function) = Field{is_time_dependent(f), typeof(f)}(f)
+
+(f::AbstractField{true})(xu, t) = f.field_function(xu, t)
+(f::AbstractField{true})(xu) = throw(ArgumentError("Time-dependent field function must have a time argument."))
+(f::AbstractField{false})(xu, t) = f.field_function(xu)
+(f::AbstractField{false})(xu) = f.field_function(xu)
 
 """
     prepare(grid, E, B; species=Proton) -> (q, m, E, B)
@@ -76,8 +105,8 @@ function prepare(grid::CartesianGrid, E::TE, B::TB; species::Species=Proton, q=1
 
    gridx, gridy, gridz = makegrid(grid)
 
-   E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz) : E
-   B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz) : B
+   E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz) : Field(E)
+   B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz) : Field(B)
 
    q, m, E, B
 end
@@ -93,9 +122,9 @@ function prepare(grid::CartesianGrid, E::TE, B::TB, F::TF; species::Species=Prot
 
    gridx, gridy, gridz = makegrid(grid)
 
-   E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz) : E
-   B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz) : B
-   F = TF <: AbstractArray ? getinterp(F, gridx, gridy, gridz) : F
+   E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz) : Field(E)
+   B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz) : Field(B)
+   F = TF <: AbstractArray ? getinterp(F, gridx, gridy, gridz) : Field(F)
 
    q, m, E, B, F
 end
@@ -109,6 +138,8 @@ and mass `m` and analytic EM field functions. Prescribed `species` are `Electron
 """
 function prepare(E, B; species::Species=Proton, q=1.0, m=1.0)
    q, m = getchargemass(species, q, m)
+   B = Field(B)
+   E = Field(E)
 
    q, m, E, B
 end
@@ -121,7 +152,7 @@ and mass `m`, analytic EM field functions, and external force `F`.
 """
 function prepare(E, B, F; species::Species=Proton, q=1.0, m=1.0)
    t = prepare(E, B; species, q, m)
-   push!(t, F)
+   push!(t, Field(F))
    t
 end
 
@@ -129,13 +160,13 @@ end
 function trace!(dy, y, p, t)
    q, m, E, B = p
    dy[1:3] = y[4:6]
-   dy[4:6] = q/m*(E(y) + y[4:6] × (B(y[1:3])))
+   dy[4:6] = q/m*(E(y, t) + y[4:6] × (B(y, t)))
 end
 
 function trace(y, p, t)
    q, m, E, B = p
    dx, dy, dz = y[4:6]
-   dux, duy, duz = q/m*(E(y) + y[4:6] × (B(y[1:3])))
+   dux, duy, duz = q/m*(E(y, t) + y[4:6] × (B(y, t)))
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
 
@@ -144,13 +175,13 @@ field."
 function trace_full!(dy, y, p, t)
    q, m, E, B, F = p
    dy[1:3] = y[4:6]
-   dy[4:6] = (q*(E(y) + y[4:6] × (B(y[1:3]))) + F(y)) / m
+   dy[4:6] = (q*(E(y, t) + y[4:6] × (B(y, t))) + F(y, t)) / m
 end
 
 function trace_full(y, p, t)
    q, m, E, B, F = p
    dx, dy, dz = y[4:6]
-   dux, duy, duz = (q*(E(y) + y[4:6] × (B(y[1:3]))) + F(y)) / m
+   dux, duy, duz = (q*(E(y, t) + y[4:6] × (B(y, t))) + F(y, t)) / m
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
 
@@ -163,7 +194,7 @@ function trace_relativistic!(dy, y, p, t)
    end
    γInv = √(1.0 - (y[4]*y[4] + y[5]*y[5] + y[6]*y[6])/c^2)
    dy[1:3] = y[4:6]
-   dy[4:6] = q/m*γInv*(E(y) + y[4:6] × (B(y[1:3])))
+   dy[4:6] = q/m*γInv*(E(y, t) + y[4:6] × (B(y, t)))
 end
 
 function trace_relativistic(y, p, t)
@@ -174,7 +205,7 @@ function trace_relativistic(y, p, t)
    end
    γInv = √(1.0 - (y[4]*y[4] + y[5]*y[5] + y[6]*y[6])/c^2)
    dx, dy, dz = y[4:6]
-   dux, duy, duz = q/m*γInv*(E(y) + y[4:6] × (B(y[1:3])))
+   dux, duy, duz = q/m*γInv*(E(y, t) + y[4:6] × (B(y, t)))
    SVector{6}(dx, dy, dz, dux, duy, duz)
 end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,6 +190,8 @@ end
 
       @test F(x0)[2] ≈ 9.10938356e-42
 
+      stateinit = SA[x0..., u0...]
+
       prob = ODEProblem(trace, stateinit, tspan, param)
       sol = solve(prob, Tsit5(); save_idxs=[1,2,3])
 


### PR DESCRIPTION
1. Adding support for time-dependent fields. Adding abstract type `AbstractField` and struct `Field`.
2. Unifying the interfaces of trace and trace_full. Adding two types of Tuple.
3. Adding related tests.
4. Improving performance.

Thanks to @henry2004y. And the work for the interfaces is finished.