### PR TITLE
Support normalized units and 2D fields

### DIFF
--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -6,7 +6,7 @@ using Interpolations: interpolate, extrapolate, BSpline, Cubic, Line, OnGrid, Pe
    scale
 using StaticArrays
 
-export prepare, trace!, trace_relativistic!, trace_normalized!, trace2d_normalized!
+export prepare, trace!, trace_relativistic!, trace_normalized!
 export trace, trace_relativistic
 export Proton, Electron, Ion, User
 
@@ -363,24 +363,11 @@ function trace_relativistic(y, p::TPTuple, t)
 end
 
 """
-    trace2d_normalized!(dy, y, p::TPNormalizedTuple, t)
-
-Normalized ODE equations for charged particle moving in static EM field with in-place form.
-`y` is a five-element vector (x, y, vx, vy, vz). Periodic boundary is applied for z.
-"""
-function trace2d_normalized!(dy, y, p::TPNormalizedTuple, t)
-   Ω, E, B = p
-   v = @view y[3:5]
-
-   dy[1] = v[1]
-   dy[2] = v[2]
-   dy[3:5] = Ω*(E(y, t) + v × B(y, t))
-end
-
-"""
     trace_normalized!(dy, y, p::TPNormalizedTuple, t)
 
 Normalized ODE equations for charged particle moving in static EM field with in-place form.
+If the field is in 2D X-Y plane, periodic boundary should be applied for the field in z via
+the extrapolation function provided by Interpolations.jl.
 """
 function trace_normalized!(dy, y, p::TPNormalizedTuple, t)
    Ω, E, B = p

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -366,7 +366,7 @@ end
     trace2d_normalized!(dy, y, p::TPNormalizedTuple, t)
 
 Normalized ODE equations for charged particle moving in static EM field with in-place form.
-`y` is a five element vector (x, y, vx, vy, vz). Periodic boundary is applied for z.
+`y` is a five-element vector (x, y, vx, vy, vz). Periodic boundary is applied for z.
 """
 function trace2d_normalized!(dy, y, p::TPNormalizedTuple, t)
    Ω, E, B = p

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -296,11 +296,11 @@ end
       x = range(-10, 10, length=15)
       y = range(-10, 10, length=20)
       B = fill(0.0, 3, length(x), length(y)) # [B₀]
-      E = fill(0.0, 3, length(x), length(y)) # [v₀B₀]
+      E = fill(0.0, 3, length(x), length(y)) # [E₀]
 
       B₀ = 10e-9
 
-      B[3,:,:,:] .= 1.0
+      B[3,:,:] .= 1.0
 
       Δx = x[2] - x[1]
       Δy = y[2] - y[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,8 +255,8 @@ end
    end
 
    @testset "normalized field" begin
-      # Basic units: length l₀, time t₀, magnetic field B₀
-      # Derived units: velocity v₀ = l₀/t₀, electric field E₀ = v₀B₀
+      # Basic scales: length l₀ [m], time t₀ [s], magnetic field B₀ [T]
+      # Derived scales: velocity v₀ = l₀/t₀ [m/s], electric field E₀ = v₀B₀ [V/m]
 
       # 3D
       x = range(-10, 10, length=15)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,12 +255,15 @@ end
    end
 
    @testset "normalized field" begin
+      # Basic units: length l₀, time t₀, magnetic field B₀
+      # Derived units: velocity v₀ = l₀/t₀, electric field E₀ = v₀B₀
+
       # 3D
       x = range(-10, 10, length=15)
       y = range(-10, 10, length=20)
       z = range(-10, 10, length=25)
       B = fill(0.0, 3, length(x), length(y), length(z)) # [B₀]
-      E = fill(0.0, 3, length(x), length(y), length(z)) # [v₀B₀]
+      E = fill(0.0, 3, length(x), length(y), length(z)) # [E₀]
 
       B₀ = 10e-9
 
@@ -274,8 +277,8 @@ end
          (x[1], y[1], z[1]),
          (Δx, Δy, Δz))
 
-      x0 = [0.0, 0.0, 0.0] # initial position, [m]
-      u0 = [1.0, 0.0, 0.0] # initial velocity, [m/s]
+      x0 = [0.0, 0.0, 0.0] # initial position [l₀]
+      u0 = [1.0, 0.0, 0.0] # initial velocity [v₀]
       stateinit = [x0..., u0...]
 
       param = prepare(mesh, E, B, B₀; species=Proton)
@@ -305,7 +308,7 @@ end
       mesh = CartesianGrid((length(x)-1, length(y)-1), (x[1], y[1]), (Δx, Δy))
 
       x0 = [0.0, 0.0] # initial position [l₀]
-      u0 = [1.0, 0.0, 0.0] # initial velocity [l₀/t₀]
+      u0 = [1.0, 0.0, 0.0] # initial velocity [v₀]
       stateinit = [x0..., u0...]
 
       param = prepare(mesh, E, B, B₀; species=Proton)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -254,7 +254,7 @@ end
       @test cal_energy(sol)/(x[1]-x0[1]+x[2]-x0[2]) ≈ 1e5
    end
 
-   @testset "normalized field" begin
+   @testset "normalized fields" begin
       # Basic scales: length l₀ [m], time t₀ [s], magnetic field B₀ [T]
       # Derived scales: velocity v₀ = l₀/t₀ [m/s], electric field E₀ = v₀B₀ [V/m]
 
@@ -307,14 +307,14 @@ end
 
       mesh = CartesianGrid((length(x)-1, length(y)-1), (x[1], y[1]), (Δx, Δy))
 
-      x0 = [0.0, 0.0] # initial position [l₀]
+      x0 = [0.0, 0.0, 0.0] # initial position [l₀]
       u0 = [1.0, 0.0, 0.0] # initial velocity [v₀]
       stateinit = [x0..., u0...]
 
       param = prepare(mesh, E, B, B₀; species=Proton)
       tspan = (0.0, 1.0)
 
-      prob = ODEProblem(trace2d_normalized!, stateinit, tspan, param)
+      prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
 
       sol = solve(prob, Tsit5(); save_idxs=[1])
 


### PR DESCRIPTION
* Add support for normalized units in gyrofrequency. Many numerical simulation outputs are saved in normalized units, which requires proper conversion to do tracing. Typical ones require a length scale $l_0$, time scale $t_0$, and magnetic field scale $B_0$. Most often the time scale is chosen to be 1 s, so the only scale required in the Lorentz force is $\Omega_0 = qB_0/m$. The electric fields have units of $\mathbf{v}\times\mathbf{B}$.

$$
\frac{d\mathbf{v}^\prime}{dt^\prime} = \Omega_0 t_0 (\mathbf{E}^\prime + \mathbf{v}^\prime \times\mathbf{B}^\prime)
$$

* Handle #41, 

* Merge docs for dispatched methods

* Explicitly list all the imported methods from Interpolation.jl.