### PR TITLE
Add WGLMakie output to doc

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,8 +52,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: src,TestParticleMakie/src
       - uses: codecov/codecov-action@v2
         with:
           file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,12 +5,14 @@ on:
       - master
     paths-ignore:
       - 'README.md'
+      - 'examples/**'
   push:
     branches:
       - master
     tags: '*'
     paths-ignore:
       - 'README.md'
+      - 'examples/**'
 env:
   JULIA_NUM_THREADS: 1
 jobs:

--- a/.github/workflows/RecipeCI.yml
+++ b/.github/workflows/RecipeCI.yml
@@ -1,15 +1,13 @@
 name: TestParticleMakie CI
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - 'TestParticleMakie/**'
     branches:
       - master
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - 'TestParticleMakie/**'
     branches:
       - master
     tags: '*'
@@ -50,7 +48,7 @@ jobs:
           && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: src,TestParticleMakie/src
+          directories: TestParticleMakie/src
       - uses: codecov/codecov-action@v2
         with:
           file: lcov.info

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,9 @@ on:
     paths-ignore:
       - 'README.md'
       - 'test/**'
+      - 'docs/**'
+      - 'examples/**'
+      - 'TestParticleMakie/**'
 
 jobs:
   Benchmark:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,10 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+JSServe = "824d6782-a2ef-11e9-3a09-e5662e0c26f9"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 TestParticle = "953b605b-f162-4481-8f7f-a191c2bb40e3"
+TestParticleMakie = "815e1cc4-5742-45dc-845d-1cec70514f1a"
+WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@ All tracing are performed in 3D, as is the nature for the fields. For a numerica
 For an analytical field, the user is responsible for providing the function for calculating the field at a given spatial location.
 The actual tracing is done through [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl), thanks to the ODE system of the equations of motion.
 
-The single particle motions are the basics in understanding the test particle method. Check the complete [tutorial](@ref) taken from Chapter Two of Introduction to Plasma Physics by F.F.Chen.
+The single particle motions are the basics in understanding the test particle method. Check the complete [Tutorial](@ref) taken from Chapter Two of Introduction to Plasma Physics by F.F.Chen.
 
 ## Installation
 


### PR DESCRIPTION
I managed to add WGLMakie output to the doc directly by basically copying the scripts from the example folder. This looks pretty good. Due to [current limitations](https://docs.makie.org/stable/documentation/backends/wglmakie/#output), 2D outputs are static, while single frame 3D outputs are interactive. This will surely be improved in the future. What do you think @TCLiuu? We may add more examples in this way.