### PR TITLE
Add an example based on magnetic mirror 

### DIFF
--- a/examples/demo_magneticmirror.jl
+++ b/examples/demo_magneticmirror.jl
@@ -1,0 +1,103 @@
+# Tracing charged particle in the magnetic mirror.
+# This example demonstrates the particle motion trajectory in a magnetic mirror
+# and also illustrates the conservation of magnetic moment.
+#
+# This example is based on `demo_magneticbottle.jl`.
+#
+# TCLiuu
+
+using TestParticle
+using TestParticle: getB_mirror
+using OrdinaryDiffEq
+using StaticArrays
+using LinearAlgebra
+using GLMakie, TestParticleMakie
+using Printf
+
+## Obtain field
+
+# Magnetic mirror parameters in SI units
+const I = 20. # current in the solenoid
+const N = 45 # number of windings
+const distance = 10. # distance between solenoids
+const a = 4.0 # radius of each coil
+
+
+function getB(xu)
+   SVector{3}(getB_mirror(xu[1], xu[2], xu[3], distance, a, I*N))
+end
+
+function getE(xu)
+   SA[0.0, 0.0, 0.0]
+end
+
+# the velocity along with the direction perpendicular to the magnetic field
+function v_perp(xu)
+   vu = @view xu[4:6]
+   B = getB(xu)
+   b = normalize(B)
+   v_pa = (vu⋅b).*b
+   return norm(vu - v_pa)
+end
+
+# magnetic field 
+absB(xu) = hypot(getB(xu)...)
+
+# μ, magnetic moment
+function mu(xu)
+   return v_perp(xu)^2/hypot(getB(xu)...)
+end
+
+Et(xu) = hypot(xu[4:6]...)
+
+## Initialize particles
+m = TestParticle.mₑ
+q = TestParticle.qₑ
+c = TestParticle.c
+
+# initial velocity, [m/s]
+v₀ = [2.75, 2.5, 1.3] .* 0.001c  # confined
+# v₀ = [0.25, 0.25, 5.9595] .* 0.01c  # escaped
+# initial position, [m]
+r₀ = [0.8, 0.8, 0.0]  # confined
+# r₀ = [1.5, 1.5, 2.4]  # escaped
+stateinit = [r₀..., v₀...]
+
+
+param = prepare(getE, getB; species=Electron)
+tspan = (0.0, 1e-4)
+
+prob = ODEProblem(trace!, stateinit, tspan, param)
+
+# Default Tsit5() and many solvers does not work in this case!
+# AB4() has better performance in maintaining magnetic moment conservation compared to AB3().
+sol_non = solve(prob, AB4(); dt=3e-9, save_idxs=[1,2,3,4,5,6])
+
+## Visualization
+# From the third figure on the right, it can be seen that the zero-order quantity of
+# magnetic moment is conserved, but its high-order part is not conserved under this definition
+# of magnetic moment and oscillates rapidly. We can observe from this the oscillation
+# characteristics of magnetic moments at different levels.
+f = monitor(sol_non, vars=[absB, v_perp, mu])
+
+# Plot coils
+θ = range(0, 2π, length=100)
+x = a.*cos.(θ)
+y = a.*sin.(θ)
+z = fill(distance/2, size(x))
+ax = f[1:3,1:3]
+lines!(ax, x, y, z, color=:red)
+z = fill(-distance/2, size(x))
+lines!(ax, x, y, z, color=:red)
+
+# # The distribution of magnetic field along the z-axis or x-axis
+# Bz(z) = hypot(getB(SA[0.0, 0.0, z])...)
+# Bx(x) = hypot(getB(SA[x, 0.0, 0.5*distance])...)
+# z = collect(-10:0.01:10)
+# x = collect(-0.99*a:0.01:0.99*a)
+# # Ba = Bz.(z)
+# Ba = Bx.(x)
+# # lines(z, Ba, color=:red)
+# lines(x, Ba, color=:red)
+
+f

--- a/src/utility/confinement.jl
+++ b/src/utility/confinement.jl
@@ -9,7 +9,7 @@ using SpecialFunctions: erf
 Get magnetic field from a magnetic mirror generated from two coils.
 
 # Arguments
-- `x,y,z::Float`: center location in [m].
+- `x,y,z::Float`: particle coordinates in [m].
 - `distance::Float`: distance between solenoids in [m].
 - `a::Float`: radius of each side coil in [m].
 - `I1::Float`: current in the solenoid times number of windings in side coils.
@@ -19,7 +19,7 @@ function getB_mirror(x, y, z, distance, a, I1)
 
    # 1st loop
    z₁ = z + 0.5*distance
-   k2 = (4*r*a / (z₁^2 + (a + r)^2) )
+   k2 = 4*r*a / (z₁^2 + (a + r)^2)
    K, E = ellipke(k2)
    Bz1 = μ₀*I1 / (2π*√(z₁^2+(a+r)^2)) * ((a^2-z₁^2-r^2)/(z₁^2+(r-a)^2)*E + K)
    Br1 = μ₀*z₁*I1/(2π*r*√(z₁^2+(a+r)^2))*((z₁^2+r^2+a^2)/(z₁^2+(r-a)^2)*E - K)
@@ -28,7 +28,7 @@ function getB_mirror(x, y, z, distance, a, I1)
 
    # 2nd loop
    z₂ = z - 0.5*distance
-   k2 = (4*r*a / (z₂^2 + (a + r)^2) )
+   k2 = 4*r*a / (z₂^2 + (a + r)^2)
    K, E = ellipke(k2)
    Bz2 = μ₀*I1 / (2π*√(z₂^2+(a+r)^2)) * ((a^2-z₂^2-r^2)/(z₂^2+(r-a)^2)*E + K)
    Br2 = μ₀*z₂*I1/(2π*r*√(z₂^2+(a+r)^2))*((z₂^2+r^2+a^2)/(z₂^2+(r-a)^2)*E - K)
@@ -55,7 +55,7 @@ Get magnetic field from a magnetic bottle.
 Reference: https://en.wikipedia.org/wiki/Magnetic_mirror#Magnetic_bottles
 
 # Arguments
-- `x,y,z::Float`: center location in [m].
+- `x,y,z::Float`: particle coordinates in [m].
 - `distance::Float`: distance between solenoids in [m].
 - `a::Float`: radius of each side coil in [m].
 - `b::Float`: radius of central coil in [m].
@@ -70,8 +70,8 @@ function getB_bottle(x, y, z, distance, a, b, I1, I2)
 
    # central loop
    z₃ = z
-   k = √(4*r*b / (z₃^2 + (b+r)^2) )
-   K, E = ellipke(k)
+   k2 = 4*r*b / (z₃^2 + (b+r)^2)
+   K, E = ellipke(k2)
    Bz3 = μ₀*I2 / (2π*√(z₃^2+(b+r)^2)) * ((b^2-z₃^2-r^2)/(z₃^2+(r-b)^2)*E + K)
    Br3 = μ₀*z₃*I2/(2π*r*√(z₃^2+(b+r)^2))*((z₃^2+r^2+b^2)/(z₃^2+(r-b)^2)*E - K)
    Bx3 = Br3 * x / r

--- a/src/utility/confinement.jl
+++ b/src/utility/confinement.jl
@@ -19,8 +19,8 @@ function getB_mirror(x, y, z, distance, a, I1)
 
    # 1st loop
    z₁ = z + 0.5*distance
-   k = √(4*r*a / (z₁^2 + (a + r)^2) )
-   K, E = ellipke(k)
+   k2 = (4*r*a / (z₁^2 + (a + r)^2) )
+   K, E = ellipke(k2)
    Bz1 = μ₀*I1 / (2π*√(z₁^2+(a+r)^2)) * ((a^2-z₁^2-r^2)/(z₁^2+(r-a)^2)*E + K)
    Br1 = μ₀*z₁*I1/(2π*r*√(z₁^2+(a+r)^2))*((z₁^2+r^2+a^2)/(z₁^2+(r-a)^2)*E - K)
    Bx1 = Br1 * x / r
@@ -28,8 +28,8 @@ function getB_mirror(x, y, z, distance, a, I1)
 
    # 2nd loop
    z₂ = z - 0.5*distance
-   k = √(4*r*a / (z₂^2 + (a + r)^2) )
-   K, E = ellipke(k)
+   k2 = (4*r*a / (z₂^2 + (a + r)^2) )
+   K, E = ellipke(k2)
    Bz2 = μ₀*I1 / (2π*√(z₂^2+(a+r)^2)) * ((a^2-z₂^2-r^2)/(z₂^2+(r-a)^2)*E + K)
    Br2 = μ₀*z₂*I1/(2π*r*√(z₂^2+(a+r)^2))*((z₂^2+r^2+a^2)/(z₂^2+(r-a)^2)*E - K)
    Bx2 = Br2 * x / r


### PR DESCRIPTION
1. Fixed a serious bug related to  magnetic field calculation of magnetic mirror.
This bug will cause serious divergence at the center axis of the magnetic field. #73 may require recalculating the relevant calculations involving magnetic mirrors.

2. Add  a new example base on a magnetic mirror.
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/106812784/232019922-63dc007a-a740-4d9e-afe2-6da5da0cc4bf.png">
From the third figure on the right, it can be seen that the zero-order quantity of magnetic moment is conserved, but its high-order part is not conserved under this definition of magnetic moment and oscillates rapidly. We can observe from this the oscillation characteristics of magnetic moments at different levels.

The bug fixed in the first item will cause magnetic moment non-conservation, as mentioned in #72.
