### PR TITLE
Add native Boris method

### DIFF
--- a/docs/examples/basics/config.json
+++ b/docs/examples/basics/config.json
@@ -1,6 +1,7 @@
 {
    "order": [
      "demo_energy_conservation.jl",
+     "demo_boris.jl",
      "demo_Buniform_Ezero.jl",
      "demo_electron_proton.jl",
      "demo_multiple.jl",

--- a/docs/examples/basics/demo_boris.jl
+++ b/docs/examples/basics/demo_boris.jl
@@ -1,0 +1,55 @@
+# ---
+# title: Boris method
+# id: demo_boris
+# date: 2023-11-13
+# author: "[Hongyang Zhou](https://github.com/henry2004y)"
+# julia: 1.10.0
+# description: Simple electron trajectory under uniform B and zero E
+# ---
+
+# This example demonstrates a single electron motion under a uniform B field. The E field is assumed to be zero such that there is no particle acceleration.
+# We use the [Boris method](https://apps.dtic.mil/sti/citations/ADA023511) for phase space conservation under a fixed time step.
+# This is compared against other ODE general algorithms for performance and accuracy.
+
+import DisplayAs #hide
+using TestParticle
+using StaticArrays
+using OrdinaryDiffEq
+using CairoMakie
+CairoMakie.activate!(type = "png")
+
+uniform_B(x) = SA[0.0, 0.0, 0.01]
+uniform_E(x) = SA[0.0, 0.0, 0.0]
+
+x0 = [0.0, 0.0, 0.0]
+v0 = [0.0, 1e5, 0.0]
+stateinit = [x0..., v0...]
+tspan = (0.0, 3e-7)
+dt = 3e-11
+param = prepare(uniform_E, uniform_B, species=Electron)
+paramBoris = BorisMethod(param)
+prob = TraceProblem(stateinit, tspan, dt, paramBoris)
+
+traj = trace_trajectory(prob);
+@time traj = trace_trajectory(prob);
+
+# Now let's compare against other ODE solvers:
+
+prob = ODEProblem(trace!, stateinit, tspan, param)
+sol1 = solve(prob, Tsit5(); adaptive=false, dt, dense=false);
+@time sol1 = solve(prob, Tsit5(); adaptive=false, dt, dense=false);
+
+sol2 = solve(prob, Tsit5());
+@time sol2 = solve(prob, Tsit5());
+
+# The phase space conservation can be visually checked by plotting the trajectory:
+
+f = Figure(resolution=(700, 600))
+ax = Axis(f[1, 1], aspect=1)
+@views lines!(ax, traj[1,:], traj[2,:], label="Boris")
+lines!(ax, sol1, linestyle=:dashdot, label="Tsit5 fixed")
+lines!(ax, sol2, linestyle=:dot, label="Tsit5 adaptive")
+axislegend(position=:lt, framevisible=false)
+f = DisplayAs.PNG(f) #hide
+
+# We can see that the Boris method is both accurate and fast. When calling OrdinaryDiffEq.jl, we recommend using `Vern9()` as a starting point instead of `Tsit5()`, especially combined with adaptive timestepping.

--- a/docs/examples/basics/demo_boris.jl
+++ b/docs/examples/basics/demo_boris.jl
@@ -24,20 +24,20 @@ uniform_E(x) = SA[0.0, 0.0, 0.0]
 x0 = [0.0, 0.0, 0.0]
 v0 = [0.0, 1e5, 0.0]
 stateinit = [x0..., v0...]
-tspan = (0.0, 3e-7)
+tspan = (0.0, 3e-6)
 dt = 3e-11
 param = prepare(uniform_E, uniform_B, species=Electron)
 paramBoris = BorisMethod(param)
 prob = TraceProblem(stateinit, tspan, dt, paramBoris)
 
-traj = trace_trajectory(prob);
-@time traj = trace_trajectory(prob);
+traj = trace_trajectory(prob; savestepinterval=10);
+@time traj = trace_trajectory(prob; savestepinterval=10);
 
 # Now let's compare against other ODE solvers:
 
 prob = ODEProblem(trace!, stateinit, tspan, param)
-sol1 = solve(prob, Tsit5(); adaptive=false, dt, dense=false);
-@time sol1 = solve(prob, Tsit5(); adaptive=false, dt, dense=false);
+sol1 = solve(prob, Tsit5(); adaptive=false, dt, dense=false, saveat=10*dt);
+@time sol1 = solve(prob, Tsit5(); adaptive=false, dt, dense=false, saveat=10*dt);
 
 sol2 = solve(prob, Tsit5());
 @time sol2 = solve(prob, Tsit5());
@@ -52,4 +52,5 @@ lines!(ax, sol2, linestyle=:dot, label="Tsit5 adaptive")
 axislegend(position=:lt, framevisible=false)
 f = DisplayAs.PNG(f) #hide
 
-# We can see that the Boris method is both accurate and fast. When calling OrdinaryDiffEq.jl, we recommend using `Vern9()` as a starting point instead of `Tsit5()`, especially combined with adaptive timestepping.
+# We can see that the Boris method is both accurate and fast; Fixed time step `Tsit5()` is ok, but adaptive `Tsit5()` is pretty bad for long time evolutions.
+# When calling OrdinaryDiffEq.jl, we recommend using `Vern9()` as a starting point instead of `Tsit5()`, especially combined with adaptive timestepping.

--- a/docs/examples/basics/demo_proton_dipole.jl
+++ b/docs/examples/basics/demo_proton_dipole.jl
@@ -66,6 +66,12 @@ function get_energy_ratio(sol)
    (Eend - Einit) / Einit
 end
 
+function get_energy_ratio(traj::Matrix)
+   Einit = traj[4,1]^2 + traj[5,1]^2 + traj[6,1]^2
+   Eend = traj[4,end]^2 + traj[5,end]^2 + traj[6,end]^2
+   (Eend - Einit) / Einit
+end
+
 sol = solve(prob, ImplicitMidpoint(); dt=1e-3)
 get_energy_ratio(sol)
 
@@ -101,4 +107,15 @@ sol = solve(prob, Vern9(); callback=cb, dt=0.1) # dt=0.1 is a dummy value
 get_energy_ratio(sol)
 
 # This is much more accurate, at the cost of significantly more iterations.
+# We can also use the Boris method implemented within the package:
+
+dt = 1e-4
+param = prepare(getE_dipole, getB_dipole, species=Electron)
+paramBoris = BorisMethod(param)
+prob = TraceProblem(stateinit, tspan, dt, paramBoris)
+traj = trace_trajectory(prob)
+get_energy_ratio(traj)
+
 # Therefore, as a rule of thumb, we should not use the default `Tsit5()` scheme. Use adaptive `Vern9()` for an unfamiliar field configuration, then switch to more accurate schemes if needed. A more thorough test can be found [here](https://github.com/henry2004y/TestParticle.jl/issues/73).
+
+

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -13,7 +13,7 @@ export trace!, trace_relativistic!, trace_normalized!, trace, trace_relativistic
 export Proton, Electron, Ion, User
 export Maxwellian, BiMaxwellian
 export orbit, monitor
-export trace_trajectory
+export TraceProblem, BorisMethod, trace_trajectory
 
 include("utility/utility.jl")
 

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -13,6 +13,7 @@ export trace!, trace_relativistic!, trace_normalized!, trace, trace_relativistic
 export Proton, Electron, Ion, User
 export Maxwellian, BiMaxwellian
 export orbit, monitor
+export trace_trajectory
 
 include("utility/utility.jl")
 
@@ -572,6 +573,7 @@ function orbit end
 
 function monitor end
 
+include("pusher.jl")
 include("precompile.jl")
 
 end

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -96,7 +96,7 @@ function cross!(v1, v2, vout)
 end
 
 function trace_trajectory(prob::TraceProblem;
-	savestepinterval::Int=1, isoutofdomain=ODE_DEFAULT_ISOUTOFDOMAIN)
+	savestepinterval::Int=1, isoutofdomain::Function=ODE_DEFAULT_ISOUTOFDOMAIN)
 	(; stateinit, tspan, dt, param) = prob
 	xv = copy(stateinit)
 	# prepare advancing

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -61,7 +61,7 @@ function cross!(v1, v2, vout)
    return
 end
 
-function solve_trajectory(param; dt, stateinit, tspan)
+function trace_trajectory(param; dt, stateinit, tspan)
    xv = copy(stateinit)
    # intermediate variables
    v_minus = Vector{Float64}(undef, 3)

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -95,20 +95,27 @@ function cross!(v1, v2, vout)
    return
 end
 
-function trace_trajectory(prob::TraceProblem)
+function trace_trajectory(prob::TraceProblem; savestepinterval::Int=1)
 	(; stateinit, tspan, dt, param) = prob
 	xv = copy(stateinit)
-   # push velocity back in time by 1/2 dt
-	update_velocity!(xv, param, -0.5*dt)
 	# prepare advancing
 	ttotal = tspan[2] - tspan[1]
 	nt = Int(ttotal ÷ dt)
-	traj = zeros(eltype(stateinit), 6, nt)
+	iout, nout = 1, nt ÷ savestepinterval + 1
+	traj = zeros(eltype(stateinit), 6, nout)
+
+	traj[:,1] = xv
+
+   # push velocity back in time by 1/2 dt
+	update_velocity!(xv, param, -0.5*dt)
 
 	for it in 1:nt
 		update_velocity!(xv, param, dt)
       update_location!(xv, dt)
-      traj[:,it] .= xv
+		if it % savestepinterval == 0
+      	iout += 1
+			traj[:,iout] .= xv
+		end
 	end
 
 	# final step if needed

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -1,0 +1,90 @@
+# Native pusher
+
+struct TraceProblem{T<:Real, TP}
+   stateinit::AbstractVector{T}
+   tspan::Tuple{T, T}
+   param::TP
+end
+
+"updates velocity using the Boris method, Birdsall, Plasma Physics via Computer Simulation, p.62"
+function update_velocity!(xv, param, dt, v_minus, v_prime, v_plus, t, s, v_minus_cross_t,
+   v_prime_cross_s)
+   q, m = param[1], param[2]
+   E = param[3](xv, 0.0)
+   B = param[4](xv, 0.0)
+	t_mag2 = 0.0
+	# t vector
+	for dim in 1:3
+	   t[dim] = q/m*B[dim]*0.5*dt
+	end
+	# magnitude of t, squared
+	t_mag2 = sum(abs2, t)
+	# s vector
+	for dim in 1:3
+	   s[dim] = 2*t[dim]/(1 + t_mag2)
+	end
+	# v-
+	for dim in 1:3
+	   v_minus[dim] = xv[dim+3] + q/m*E[dim]*0.5*dt
+   end
+	# v′
+   cross!(v_minus, t, v_minus_cross_t)
+	for dim in 1:3
+	   v_prime[dim] = v_minus[dim] + v_minus_cross_t[dim]
+   end
+	# v+
+   cross!(v_prime, s, v_prime_cross_s)
+	for dim in 1:3
+	   v_plus[dim] = v_minus[dim] + v_prime_cross_s[dim]
+   end
+	# v[n+1/2]
+	for dim in 1:3
+	   xv[dim+3] = v_plus[dim] + q/m*E[dim]*0.5*dt
+   end
+
+   return
+end
+
+function update_location!(xv, dt)
+	xv[1] += xv[4]*dt
+	xv[2] += xv[5]*dt
+	xv[3] += xv[6]*dt
+
+   return
+end
+
+function cross!(v1, v2, vout)
+	vout[1] = v1[2]*v2[3] - v1[3]*v2[2]
+	vout[2] = -v1[1]*v2[3] + v1[3]*v2[1]
+	vout[3] = v1[1]*v2[2] - v1[2]*v2[1]
+
+   return
+end
+
+function solve_trajectory(param; dt, stateinit, tspan)
+   xv = copy(stateinit)
+   # intermediate variables
+   v_minus = Vector{Float64}(undef, 3)
+	v_prime = Vector{Float64}(undef, 3)
+	v_plus = Vector{Float64}(undef, 3)
+	t = Vector{Float64}(undef, 3)
+	s = Vector{Float64}(undef, 3)
+   v_minus_cross_t = Vector{Float64}(undef, 3)
+   v_prime_cross_s = Vector{Float64}(undef, 3)
+	# push velocity back in time by 1/2 dt
+	update_velocity!(xv, param, -0.5*dt, v_minus, v_prime, v_plus, t, s, v_minus_cross_t,
+      v_prime_cross_s)
+   #TODO: get this right!
+   nt = 1000
+   output = zeros(6, nt)
+   for it in 1:nt
+      update_velocity!(xv, param, -0.5*dt, v_minus, v_prime, v_plus, t, s, v_minus_cross_t,
+         v_prime_cross_s)
+      update_location!(xv, dt)
+
+      output[:,it] .= xv
+   end
+
+   output
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -376,9 +376,10 @@ end
       paramBoris = BorisMethod(param)
       prob = TraceProblem(stateinit, tspan, dt, paramBoris)
 
-      traj = trace_trajectory(prob)
+      traj = trace_trajectory(prob; savestepinterval=10)
 
-      @test traj[:, end] == [-0.00010010246586798348, 3.696468748841441e-5, 0.0, -66972.936997493, -74260.52592009991, 0.0]
+      @test traj[:, end] == [-7.84237771267459e-5, 5.263661571564935e-5, 0.0,
+         -93512.6374393526, -35431.43574759836, 0.0]
    end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -362,6 +362,22 @@ end
       xs = getindex.(sol.u, 1)
       @test length(xs) == 8 && xs[end] ≈ 0.8540967195469715
    end
+
+   @testset "Boris pusher" begin
+      uniform_B(x) = SA[0.0, 0.0, 0.01]
+      uniform_E(x) = SA[0.0, 0.0, 0.0]
+
+      x0 = [0.0, 0.0, 0.0]
+      v0 = [0.0, 1e5, 0.0]
+      stateinit = [x0..., v0...]
+      tspan = (0, 10)
+      dt = 3e-11
+      param = prepare(uniform_E, uniform_B, species=Electron)
+
+      output = trace_trajectory(param; dt, stateinit, tspan)
+
+      @test size(output) == (6, 1000)
+   end
 end
 
 if "makie" in ARGS

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -370,13 +370,15 @@ end
       x0 = [0.0, 0.0, 0.0]
       v0 = [0.0, 1e5, 0.0]
       stateinit = [x0..., v0...]
-      tspan = (0, 10)
+      tspan = (0.0, 3e-8)
       dt = 3e-11
       param = prepare(uniform_E, uniform_B, species=Electron)
+      paramBoris = BorisMethod(param)
+      prob = TraceProblem(stateinit, tspan, dt, paramBoris)
 
-      output = trace_trajectory(param; dt, stateinit, tspan)
+      traj = trace_trajectory(prob)
 
-      @test size(output) == (6, 1000)
+      @test traj[:, end] == [-0.00010010246586798348, 3.696468748841441e-5, 0.0, -66972.936997493, -74260.52592009991, 0.0]
    end
 end
 


### PR DESCRIPTION
It's time to add some native particle pushers in the package!

## Background

The Boris method is the de facto particle pusher in plasma physics, because of its excellent conservation behavior and relative simplicity. The Boris method is a second order method with discrete phase error related to the choice of fixed time step. If the time step is not fixed, this method can still be used, but the conservation of phase space trajectory will be violated.

## Why do we need this?

The Boris method is specifically designed for the expression of Lorentz force. A general ODE solver in OrdinaryDiffEq.jl does not take into account the special form of the Lorentz equation, which is also the reason why the Boris method does not exist in OrdinaryDiffEq.jl. With my recent tests on multiple algorithms from OrdinaryDiffEq.jl, the default `Tsit5()` has poor conservation properties in many cases, and there are only a few options that display nice energy conservation behaviors #73. The Boris method also requires a fixed timestep for conservation, which makes it a bit harder for investigating a new problem, but we should have a version of our own in this package.

## Plan

- [x] Implementing a first working version of the Boris method with similar APIs to the ODE solver.
- [x] Cleaning up the code.
- [x] Testing the accuracy and performance compared with other ODE solvers.
- [x] Add a demo using the native Boris method.