### PR TITLE
Support Interpolations 0.15

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestParticle"
 uuid = "953b605b-f162-4481-8f7f-a191c2bb40e3"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>, and Tiancheng Liu <liutc@mail.nankai.edu.cn>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -25,7 +25,7 @@ TestParticleMakie = "Makie"
 [compat]
 Distributions = "0.25"
 Elliptic = "1.0"
-Interpolations = "0.14"
+Interpolations = "0.14, 0.15"
 Makie = "0.20"
 Meshes = "0.32, 0.33, 0.34, 0.35, 0.36"
 PrecompileTools = "1.0"


### PR DESCRIPTION
Interpolations v0.15 is [stalled by KernelDensity](https://github.com/JuliaStats/KernelDensity.jl/pull/119) currently, so we can wait a little bit for that one. 