### PR TITLE
Add option to choose BC types for numerical fields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestParticle"
 uuid = "953b605b-f162-4481-8f7f-a191c2bb40e3"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>, and Tiancheng Liu <liutc@mail.nankai.edu.cn>"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/docs/examples/basics/config.json
+++ b/docs/examples/basics/config.json
@@ -4,6 +4,7 @@
      "demo_boris.jl",
      "demo_Buniform_Ezero.jl",
      "demo_dimensionless.jl",
+     "demo_dimensionless_periodic.jl",
      "demo_electron_proton.jl",
      "demo_multiple.jl",
      "demo_ExB_drift.jl",

--- a/docs/examples/basics/demo_dimensionless_periodic.jl
+++ b/docs/examples/basics/demo_dimensionless_periodic.jl
@@ -1,0 +1,67 @@
+# ---
+# title: Tracing with Dimensionless Units and Periodic Boundary
+# id: demo_dimensionless_periodic
+# date: 2023-12-15
+# author: "[Hongyang Zhou](https://github.com/henry2004y)"
+# julia: 1.9.4
+# description: Tracing charged particle in dimensionless units and periodic boundary
+# ---
+
+# This example shows how to trace charged particles in dimensionless units and EM fields with periodic boundaries.
+# For details about dimensionless units, please check another [example](@id demo_dimensionless).
+
+# Now let's demonstrate this with `trace_normalized!`.
+
+import DisplayAs #hide
+using TestParticle
+using OrdinaryDiffEq
+using Meshes
+using StaticArrays
+using CairoMakie
+CairoMakie.activate!(type = "png")
+
+x = range(-10, 10, length=15)
+y = range(-10, 10, length=20)
+B = fill(0.0, 3, length(x), length(y)) # [B₀]
+
+E(x) = SA[0.0, 0.0, 0.0]
+
+B₀ = 10e-9
+
+B[3,:,:] .= 1.0
+
+Δx = x[2] - x[1]
+Δy = y[2] - y[1]
+
+grid = CartesianGrid((length(x)-1, length(y)-1), (x[1], y[1]), (Δx, Δy))
+
+## If bc == 1, we set a NaN value outside the domain (default for 3D grids);
+## If bc == 2, we set periodic boundary conditions (default for 2D grids).
+param = prepare(grid, E, B, B₀; species=Proton, bc=2)
+
+Ω = param[1]
+U₀ = 1.0
+
+# Note that we set a radius of 10, so the trajectory extent from -20 to 0 in y, which is beyond the original y range.
+
+x0 = [0.0, 0.0, 0.0] # initial position [l₀]
+u0 = [10*Ω*U₀, 0.0, 0.0] # initial velocity [v₀]
+stateinit = [x0..., u0...]
+tspan = (0.0, 1.5π/Ω) # 3/4 gyroperiod
+
+prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
+sol = solve(prob, Vern9())
+
+### Visualization
+f = Figure(fontsize = 18)
+ax = Axis(f[1, 1],
+   title = "Proton trajectory",
+   xlabel = "X",
+   ylabel = "Y",
+   limits = (-10.1, 10.1, -20.1, 0.1),
+   aspect = DataAspect()
+)
+
+lines!(ax, sol, vars=(1,2))
+
+f = DisplayAs.PNG(f) #hide

--- a/docs/examples/basics/demo_dimensionless_periodic.jl
+++ b/docs/examples/basics/demo_dimensionless_periodic.jl
@@ -35,8 +35,8 @@ B[3,:,:] .= 1.0
 
 grid = CartesianGrid((length(x)-1, length(y)-1), (x[1], y[1]), (Δx, Δy))
 
-## If bc == 1, we set a NaN value outside the domain (default for 3D grids);
-## If bc == 2, we set periodic boundary conditions (default for 2D grids).
+## If bc == 1, we set a NaN value outside the domain (default);
+## If bc == 2, we set periodic boundary conditions.
 param = prepare(grid, E, B, B₀; species=Proton, bc=2)
 
 Ω = param[1]

--- a/docs/examples/basics/demo_dimensionless_periodic.jl
+++ b/docs/examples/basics/demo_dimensionless_periodic.jl
@@ -8,7 +8,7 @@
 # ---
 
 # This example shows how to trace charged particles in dimensionless units and EM fields with periodic boundaries.
-# For details about dimensionless units, please check another [example](@id demo_dimensionless).
+# For details about dimensionless units, please check another [example](@ref demo_dimensionless).
 
 # Now let's demonstrate this with `trace_normalized!`.
 

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -309,8 +309,9 @@ Return a tuple consists of particle charge, mass for a prescribed `species` of c
 and mass `m`, interpolated EM field functions, and external force `F`.
 
     prepare(x::AbstractRange, y::AbstractRange, z::AbstractRange, E, B) -> (q2m, E, B)
+    prepare(x, y, E, B) -> (q2m, E, B)
 
-Direct range input for uniform grid in 3D is also accepted.
+Direct range input for uniform grid in 2/3D is also accepted.
 
     prepare(E, B; species=Proton, q=1.0, m=1.0) -> (q2m, E, B)
 

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -3,7 +3,7 @@ module TestParticle
 using LinearAlgebra: norm, ×, ⋅
 using Meshes: coordinates, spacing, embeddim, CartesianGrid
 using Interpolations: interpolate, extrapolate, scale, BSpline, Linear, Quadratic, Cubic,
-   Line, OnGrid, Periodic
+   Line, OnCell, Periodic
 using Distributions: MvNormal
 using StaticArrays
 using PrecompileTools: @setup_workload, @compile_workload
@@ -97,26 +97,25 @@ function makegrid(grid::CartesianGrid{2, T}) where T
    gridx, gridy
 end
 
-function getinterp(A, gridx, gridy, gridz, order::Int=1)
+"""
+    getinterp(A, gridx, gridy, gridz, order::Int=1, bc::Int=1)
+    getinterp(A, gridx, gridy, order::Int=1, bc::Int=1)
+
+Return a function for interpolating array `A` on the grid given by `gridx`, `gridy`, and
+`gridz`.
+
+# Arguments
+- `order::Int=1`: order of interpolation in [1,2,3].
+- `bc::Int=1`: type of boundary conditions, 1 -> NaN, 2 -> periodic.
+"""
+function getinterp(A, gridx, gridy, gridz, order::Int=1, bc::Int=1)
    @assert size(A,1) == 3 && ndims(A) == 4 "Inconsistent 3D force field and grid!"
 
    Ax = @view A[1,:,:,:]
    Ay = @view A[2,:,:,:]
    Az = @view A[3,:,:,:]
 
-   if order == 1
-      itpx = extrapolate(interpolate(Ax, BSpline(Linear())), NaN)
-      itpy = extrapolate(interpolate(Ay, BSpline(Linear())), NaN)
-      itpz = extrapolate(interpolate(Az, BSpline(Linear())), NaN)
-   elseif order == 2
-      itpx = extrapolate(interpolate(Ax, BSpline(Quadratic())), NaN)
-      itpy = extrapolate(interpolate(Ay, BSpline(Quadratic())), NaN)
-      itpz = extrapolate(interpolate(Az, BSpline(Quadratic())), NaN)
-   elseif order == 3
-      itpx = extrapolate(interpolate(Ax, BSpline(Cubic(Line(OnGrid())))), NaN)
-      itpy = extrapolate(interpolate(Ay, BSpline(Cubic(Line(OnGrid())))), NaN)
-      itpz = extrapolate(interpolate(Az, BSpline(Cubic(Line(OnGrid())))), NaN)
-   end
+   itpx, itpy, itpz = _getinterp(Ax, Ay, Az, order, bc)
 
    interpx = scale(itpx, gridx, gridy, gridz)
    interpy = scale(itpy, gridx, gridy, gridz)
@@ -132,27 +131,14 @@ function getinterp(A, gridx, gridy, gridz, order::Int=1)
    return get_field
 end
 
-function getinterp(A, gridx, gridy, order::Int=1)
+function getinterp(A, gridx, gridy, order::Int=1, bc::Int=2)
    @assert size(A,1) == 3 && ndims(A) == 3 "Inconsistent 2D force field and grid!"
 
    Ax = @view A[1,:,:]
    Ay = @view A[2,:,:]
    Az = @view A[3,:,:]
 
-   # The most common boundary condition for 2D is periodic.
-   if order == 1
-      itpx = extrapolate(interpolate(Ax, BSpline(Linear())), Periodic())
-      itpy = extrapolate(interpolate(Ay, BSpline(Linear())), Periodic())
-      itpz = extrapolate(interpolate(Az, BSpline(Linear())), Periodic())
-   elseif order == 2
-      itpx = extrapolate(interpolate(Ax, BSpline(Quadratic())), Periodic())
-      itpy = extrapolate(interpolate(Ay, BSpline(Quadratic())), Periodic())
-      itpz = extrapolate(interpolate(Az, BSpline(Quadratic())), Periodic())
-   elseif order == 3
-      itpx = extrapolate(interpolate(Ax, BSpline(Cubic(Periodic(OnGrid())))), Periodic())
-      itpy = extrapolate(interpolate(Ay, BSpline(Cubic(Periodic(OnGrid())))), Periodic())
-      itpz = extrapolate(interpolate(Az, BSpline(Cubic(Periodic(OnGrid())))), Periodic())
-   end
+   itpx, itpy, itpz = _getinterp(Ax, Ay, Az, order, bc)
 
    interpx = scale(itpx, gridx, gridy)
    interpy = scale(itpy, gridx, gridy)
@@ -166,6 +152,43 @@ function getinterp(A, gridx, gridy, order::Int=1)
    end
 
    return get_field
+end
+
+function _getinterp(Ax, Ay, Az, order::Int, bc::Int)
+   gtype = OnCell()
+
+   if bc == 1
+      if order == 1
+         itpx = extrapolate(interpolate(Ax, BSpline(Linear())), NaN)
+         itpy = extrapolate(interpolate(Ay, BSpline(Linear())), NaN)
+         itpz = extrapolate(interpolate(Az, BSpline(Linear())), NaN)
+      elseif order == 2
+         itpx = extrapolate(interpolate(Ax, BSpline(Quadratic())), NaN)
+         itpy = extrapolate(interpolate(Ay, BSpline(Quadratic())), NaN)
+         itpz = extrapolate(interpolate(Az, BSpline(Quadratic())), NaN)
+      elseif order == 3
+         itpx = extrapolate(interpolate(Ax, BSpline(Cubic(Line(gtype)))), NaN)
+         itpy = extrapolate(interpolate(Ay, BSpline(Cubic(Line(gtype)))), NaN)
+         itpz = extrapolate(interpolate(Az, BSpline(Cubic(Line(gtype)))), NaN)
+      end
+   else
+      bctype = Periodic()
+      if order == 1
+         itpx = extrapolate(interpolate(Ax, BSpline(Linear(bctype))), bctype)
+         itpy = extrapolate(interpolate(Ay, BSpline(Linear(bctype))), bctype)
+         itpz = extrapolate(interpolate(Az, BSpline(Linear(bctype))), bctype)
+      elseif order == 2
+         itpx = extrapolate(interpolate(Ax, BSpline(Quadratic(Periodic(gtype)))), bctype)
+         itpy = extrapolate(interpolate(Ay, BSpline(Quadratic(Periodic(gtype)))), bctype)
+         itpz = extrapolate(interpolate(Az, BSpline(Quadratic(Periodic(gtype)))), bctype)
+      elseif order == 3
+         itpx = extrapolate(interpolate(Ax, BSpline(Cubic(Periodic(gtype)))), bctype)
+         itpy = extrapolate(interpolate(Ay, BSpline(Cubic(Periodic(gtype)))), bctype)
+         itpz = extrapolate(interpolate(Az, BSpline(Cubic(Periodic(gtype)))), bctype)
+      end
+   end
+
+   itpx, itpy, itpz
 end
 
 "Judge whether the field function is time dependent."
@@ -271,6 +294,10 @@ end
 Return a tuple consists of particle charge-mass ratio for a prescribed `species` and
 interpolated EM field functions.
 
+# keywords
+- `order::Int=1`: order of interpolation in [1,2,3].
+- `bc::Int=1`: type of boundary conditions, 1 -> NaN, 2 -> periodic.
+
     prepare(grid::CartesianGrid, E, B, B₀::Real; species=Proton) -> (Ω, E, B)
 
 Return a tuple consists of gyrofrequency for normalization and interpolated EM field
@@ -297,75 +324,75 @@ Return a tuple consists of particle charge, mass for a prescribed `species` of c
 and mass `m`, analytic EM field functions, and external force `F`.
 """
 function prepare(grid::CartesianGrid, E::TE, B::TB; species::Species=Proton,
-   q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1) where {TE, TB}
+   q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1, bc::Int=1) where {TE, TB}
 
    q, m = getchargemass(species, q, m)
 
    if embeddim(grid) == 3
       gridx, gridy, gridz = makegrid(grid)
-      E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz, order) : E
-      B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz, order) : B
+      E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz, order, bc) : E
+      B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz, order, bc) : B
    elseif embeddim(grid) == 2
       gridx, gridy = makegrid(grid)
-      E = TE <: AbstractArray ? getinterp(E, gridx, gridy, order) : E
-      B = TB <: AbstractArray ? getinterp(B, gridx, gridy, order) : B
+      E = TE <: AbstractArray ? getinterp(E, gridx, gridy, order, bc) : E
+      B = TB <: AbstractArray ? getinterp(B, gridx, gridy, order, bc) : B
    end
 
    q/m, Field(E), Field(B)
 end
 
 function prepare(grid::CartesianGrid, E::TE, B::TB, B₀::Real; species::Species=Proton,
-   q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1) where {TE, TB}
+   q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1, bc::Int=1) where {TE, TB}
 
    q, m = getchargemass(species, q, m)
    Ω = q*B₀/m
 
    if embeddim(grid) == 3
       gridx, gridy, gridz = makegrid(grid)
-      E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz, order) : E
-      B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz, order) : B
+      E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz, order, bc) : E
+      B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz, order, bc) : B
    elseif embeddim(grid) == 2
       gridx, gridy = makegrid(grid)
-      E = TE <: AbstractArray ? getinterp(E, gridx, gridy, order) : E
-      B = TB <: AbstractArray ? getinterp(B, gridx, gridy, order) : B
+      E = TE <: AbstractArray ? getinterp(E, gridx, gridy, order, bc) : E
+      B = TB <: AbstractArray ? getinterp(B, gridx, gridy, order, bc) : B
    end
 
    Ω, Field(E), Field(B)
 end
 
 function prepare(grid::CartesianGrid, E::TE, B::TB, F::TF; species::Species=Proton,
-   q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1) where {TE, TB, TF}
+   q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1, bc::Int=1) where {TE, TB, TF}
 
    q, m = getchargemass(species, q, m)
 
    gridx, gridy, gridz = makegrid(grid)
 
-   E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz, order) : E
-   B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz, order) : B
-   F = TF <: AbstractArray ? getinterp(F, gridx, gridy, gridz, order) : F
+   E = TE <: AbstractArray ? getinterp(E, gridx, gridy, gridz, order, bc) : E
+   B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz, order, bc) : B
+   F = TF <: AbstractArray ? getinterp(F, gridx, gridy, gridz, order, bc) : F
 
    q, m, Field(E), Field(B), Field(F)
 end
 
 function prepare(x, y, E::TE, B::TB; species::Species=Proton,
-   q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1) where {TE, TB}
+   q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1, bc::Int=1) where {TE, TB}
 
    q, m = getchargemass(species, q, m)
 
-   E = TE <: AbstractArray ? getinterp(E, x, y, order) : E
-   B = TB <: AbstractArray ? getinterp(B, x, y, order) : B
+   E = TE <: AbstractArray ? getinterp(E, x, y, order, bc) : E
+   B = TB <: AbstractArray ? getinterp(B, x, y, order, bc) : B
 
    q/m, Field(E), Field(B)
 end
 
 function prepare(x::T, y::T, z::T, E::TE, B::TB;
-   species::Species=Proton, q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1) where
-   {T<:AbstractRange, TE, TB}
+   species::Species=Proton, q::AbstractFloat=1.0, m::AbstractFloat=1.0, order::Int=1,
+   bc::Int=1) where {T<:AbstractRange, TE, TB}
 
    q, m = getchargemass(species, q, m)
 
-   E = TE <: AbstractArray ? getinterp(E, x, y, z, order) : E
-   B = TB <: AbstractArray ? getinterp(B, x, y, z, order) : B
+   E = TE <: AbstractArray ? getinterp(E, x, y, z, order, bc) : E
+   B = TB <: AbstractArray ? getinterp(B, x, y, z, order, bc) : B
 
    q/m, Field(E), Field(B)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -344,8 +344,8 @@ end
       u0 = [1.0, 0.0, 0.0] # initial velocity [v₀]
       stateinit = [x0..., u0...]
       tspan = (0.0, 1.0)
-
-      param = prepare(grid, E, B, B₀; species=Proton)
+      # periodic BC
+      param = prepare(grid, E, B, B₀; species=Proton, bc=2)
       prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
       sol = solve(prob, Tsit5(); save_idxs=[1])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ end
       Δy = y[2] - y[1]
       Δz = z[2] - z[1]
 
-      mesh = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
+      grid = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
          (x[1], y[1], z[1]),
          (Δx, Δy, Δz))
 
@@ -71,7 +71,7 @@ end
       sol = solve(prob, Tsit5(); save_idxs=[1], isoutofdomain, verbose=false)
       @test getindex.(sol.u, 1)[end] ≈ 0.7388945226814018
 
-      param = prepare(mesh, E, B)
+      param = prepare(grid, E, B)
       prob = ODEProblem(trace!, stateinit, tspan, param)
       sol = solve(prob, Tsit5(); save_idxs=[1])
 
@@ -92,7 +92,7 @@ end
       stateinit = SA[x0..., u0...]
       tspan = (0.0, 1.0)
 
-      param = prepare(mesh, E, B)
+      param = prepare(grid, E, B)
       prob = ODEProblem(trace, stateinit, tspan, param)
       sol = solve(prob, Tsit5(); save_idxs=[1])
 
@@ -151,7 +151,7 @@ end
       Δy = y[2] - y[1]
       Δz = z[2] - z[1]
 
-      mesh = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
+      grid = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
          (x[1], y[1], z[1]),
          (Δx, Δy, Δz))
 
@@ -160,7 +160,7 @@ end
       stateinit = [x0..., u0...]
       tspan = (0.0, 1.0)
 
-      param = prepare(mesh, E_field, B, F; species=Electron)
+      param = prepare(grid, E_field, B, F; species=Electron)
       prob = ODEProblem(trace!, stateinit, tspan, param)
       sol = solve(prob, Tsit5(); save_idxs=[1,2])
 
@@ -184,7 +184,7 @@ end
       Δy = y[2] - y[1]
       Δz = z[2] - z[1]
 
-      mesh = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
+      grid = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
          (x[1], y[1], z[1]),
          (Δx, Δy, Δz))
 
@@ -193,7 +193,7 @@ end
       stateinit = [x0..., u0...]
       tspan = (0.0, 1.0)
 
-      param = prepare(mesh, E_field, B_field, F; species=Electron)
+      param = prepare(grid, E_field, B_field, F; species=Electron)
       prob = ODEProblem(trace!, stateinit, tspan, param)
       sol = solve(prob, Tsit5(); save_idxs=[1,2,3])
 
@@ -304,11 +304,11 @@ end
       Δy = y[2] - y[1]
       Δz = z[2] - z[1]
 
-      mesh = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
+      grid = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
          (x[1], y[1], z[1]),
          (Δx, Δy, Δz))
 
-      param = prepare(mesh, E, B, B₀; species=Proton)
+      param = prepare(grid, E, B, B₀; species=Proton)
 
       x0 = [0.0, 0.0, 0.0] # initial position [l₀]
       u0 = [1.0*param[1], 0.0, 0.0] # initial velocity [v₀]
@@ -332,20 +332,20 @@ end
 
       B[3,:,:] .= 1.0
 
-      param = prepare(x, y, E, B./B₀; species=Proton)
+      param = prepare(x, y, E, B.*B₀; species=Proton)
       @test param[3] isa TestParticle.Field
 
       Δx = x[2] - x[1]
       Δy = y[2] - y[1]
 
-      mesh = CartesianGrid((length(x)-1, length(y)-1), (x[1], y[1]), (Δx, Δy))
+      grid = CartesianGrid((length(x)-1, length(y)-1), (x[1], y[1]), (Δx, Δy))
 
       x0 = [0.0, 0.0, 0.0] # initial position [l₀]
       u0 = [1.0, 0.0, 0.0] # initial velocity [v₀]
       stateinit = [x0..., u0...]
       tspan = (0.0, 1.0)
 
-      param = prepare(mesh, E, B, B₀; species=Proton)
+      param = prepare(grid, E, B, B₀; species=Proton)
       prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
       sol = solve(prob, Tsit5(); save_idxs=[1])
 
@@ -353,14 +353,14 @@ end
       @test length(xs) == 8 && xs[end] ≈ 0.8540967195469715
 
       # Because the field is uniform, the order of interpolation does not matter.
-      param = prepare(mesh, E, B, B₀; order=2)
+      param = prepare(grid, E, B, B₀; order=2)
       prob = remake(prob; p=param)
       sol = solve(prob, Tsit5(); save_idxs=[1])
       xs = getindex.(sol.u, 1)
       @test length(xs) == 8 && xs[end] ≈ 0.8540967195469715
 
       # Because the field is uniform, the order of interpolation does not matter.
-      param = prepare(mesh, E, B, B₀; order=3)
+      param = prepare(grid, E, B, B₀; order=3)
       prob = remake(prob; p=param)
       sol = solve(prob, Tsit5(); save_idxs=[1])
       xs = getindex.(sol.u, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using TestParticle, OrdinaryDiffEq, StaticArrays, Random
-using TestParticle: Field, qₑ, mₑ, c, guiding_center
+using TestParticle: Field, qₑ, mₑ, c, guiding_center, get_gc
 using Meshes: CartesianGrid
 using Test
 
@@ -124,6 +124,7 @@ end
       x = getindex.(sol.u, 1)
 
       @test guiding_center([stateinit..., 0.0], param)[1] == 1.59275e7
+      @test get_gc(param) isa Tuple
       @test x[300] ≈ 1.2563192407332942e7 rtol=1e-6
 
       # static array version (results not identical with above: maybe some bugs?)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using TestParticle, OrdinaryDiffEq, StaticArrays, Random
-using TestParticle: Field, qₑ, mₑ, c
+using TestParticle: Field, qₑ, mₑ, c, guiding_center
 using Meshes: CartesianGrid
 using Test
 
@@ -123,6 +123,7 @@ end
 
       x = getindex.(sol.u, 1)
 
+      @test guiding_center([stateinit..., 0.0], param)[1] == 1.59275e7
       @test x[300] ≈ 1.2563192407332942e7 rtol=1e-6
 
       # static array version (results not identical with above: maybe some bugs?)
@@ -202,6 +203,7 @@ end
       z = getindex.(sol.u, 3)
 
       @test x[end] ≈ -1.2828663442681638 && y[end] ≈ 1.5780464321537067 && z[end] ≈ 1.0
+      @test guiding_center([stateinit..., 0.0], param)[1] == -0.5685630064930044
 
       F_field(r) = SA[0, 9.10938356e-42, 0] # [N]
 


### PR DESCRIPTION
* When dealing with periodic boundaries, it is almost always correct to use `OnCell()` instead of `OnGrid()`.
* Add a new argument `bc` to allow switching between periodic BC and NaN BC.