### PR TITLE
Add demos with additional diagnostics

### DIFF
--- a/docs/examples/basics/config.json
+++ b/docs/examples/basics/config.json
@@ -7,6 +7,7 @@
      "demo_dimensionless_periodic.jl",
      "demo_dimensionless_dimensional.jl",
      "demo_savingcallback.jl",
+     "demo_output_func.jl",
      "demo_electron_proton.jl",
      "demo_multiple.jl",
      "demo_ExB_drift.jl",

--- a/docs/examples/basics/demo_output_func.jl
+++ b/docs/examples/basics/demo_output_func.jl
@@ -1,0 +1,119 @@
+# ---
+# title: Ensemble tracing with extra saving
+# id: demo_output_func
+# date: 2023-12-20
+# author: "[Hongyang Zhou](https://github.com/henry2004y)"
+# julia: 1.9.4
+# description: Tracing multiple charged particles in a static EM field
+# ---
+
+# This example demonstrates tracing multiple protons in an analytic E field and numerical B field.
+# It also combines one type of normalization using a reference velocity `U₀`, a reference magnetic field `B₀`, and an initial reference gyroradius `rL`.
+# One way to think of this is that a proton with initial perpendicular velocity `U₀` will gyrate with a radius `rL`.
+# Check [demo_ensemble](@ref demo_ensemble) for basic usages of the ensemble problem.
+# The `output_func` argument can be used to change saving outputs. It works as a reduction function, but here we demonstrate how to add additional outputs.
+# Besides the regular outputs, we also save the magnetic field along the trajectory, together with the parallel velocity.
+
+import DisplayAs #hide
+using TestParticle
+using OrdinaryDiffEq
+using StaticArrays
+using Statistics
+using LinearAlgebra
+using CairoMakie
+CairoMakie.activate!(type = "png")
+
+"Set initial state for EnsembleProblem."
+function prob_func(prob, i, repeat)
+   B0 = prob.p[3](prob.u0)
+   B0 = normalize(B0)
+
+   Bperp1 = SA[0.0, -B0[3], B0[2]] |> normalize
+   Bperp2 = B0 × Bperp1 |> normalize
+
+   ## initial azimuthal angle
+   ϕ = 2π*rand()
+   ## initial pitch angle
+   θ = acos(0.5)
+
+   sinϕ, cosϕ = sincos(ϕ)
+   prob.u0[4:6] = @. (B0*cos(θ) + Bperp1*(sin(θ)*cosϕ) + Bperp2*(sin(θ)*sinϕ)) * U₀
+
+   prob
+end
+
+## Analytical electric field
+E(x) = SA[0.0, 0.0, 0.0]
+## Number of cells for the field along each dimension
+nx, ny, nz = 4, 6, 8
+## Spatial extent along each dimension
+x = range(-10.0, 10.0, length=nx)
+y = range(-10.0, 10.0, length=ny)
+z = range(-10.0, 10.0, length=nz)
+
+## Numerical magnetic field
+B = Array{Float32, 4}(undef, 3, nx, ny, nz)
+
+B[1,:,:,:] .= 0.0
+B[2,:,:,:] .= 0.0
+B[3,:,:,:] .= 1.0
+
+Bmag = @views hypot.(B[1,:,:,:], B[2,:,:,:], B[3,:,:,:])
+
+B₀ = sqrt(mean(vec(Bmag) .^ 2))
+
+const U₀ = 1.0
+const rL = 4.0
+
+Ω = q2mc = U₀ / (rL*B₀)
+
+## By default User type assumes q=1, m=1
+## bc=2 uses periodic boundary conditions
+param = prepare(x, y, z, E, B, Ω; species=User, bc=2)
+
+x0 = [0.0, 0.0, 0.0] # initial position [l₀]
+u0 = [1U₀, 0.0, 0.0] # initial velocity [v₀]
+stateinit = [x0..., u0...]
+tspan = (0.0, 2π/Ω) # one averaged gyroperiod based on B₀
+
+saveat = tspan[2] / 40 # save interval
+
+prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
+
+saved_values = SavedValues(Float64, Tuple{SVector{3, Float64}, Float64})
+
+"Set customized outputs for the ensemble problem."
+function output_func(sol, i)
+   Bfunc = sol.prob.p[3]
+   b = Bfunc.(sol.u)
+
+   μ = [@views b[i] ⋅ sol[4:6, i] / hypot(b[i]...) for i in eachindex(sol)]
+
+   (sol.u, b, μ), false
+end
+
+## Number of trajectories
+trajectories = 2
+
+ensemble_prob = EnsembleProblem(prob; prob_func, output_func, safetycopy=false)
+sols = solve(ensemble_prob, Vern9(), EnsembleThreads(); trajectories, saveat)
+
+## Visualization
+
+f = Figure(fontsize = 18)
+ax = Axis3(f[1, 1],
+   title = "Proton trajectories",
+   xlabel = "X",
+   ylabel = "Y",
+   zlabel = "Z",
+   aspect = :data,
+)
+
+for i in eachindex(sols)
+   xp = [s[1] for s in sols[i][1]]
+   yp = [s[2] for s in sols[i][1]]
+   zp = [s[3] for s in sols[i][1]]
+   lines!(ax, xp, yp, zp, label="$i")
+end
+
+f = DisplayAs.PNG(f) #hide

--- a/docs/examples/basics/demo_output_func.jl
+++ b/docs/examples/basics/demo_output_func.jl
@@ -80,8 +80,6 @@ saveat = tspan[2] / 40 # save interval
 
 prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
 
-saved_values = SavedValues(Float64, Tuple{SVector{3, Float64}, Float64})
-
 "Set customized outputs for the ensemble problem."
 function output_func(sol, i)
    Bfunc = sol.prob.p[3]

--- a/docs/examples/basics/demo_savingcallback.jl
+++ b/docs/examples/basics/demo_savingcallback.jl
@@ -1,47 +1,24 @@
 # ---
-# title: Ensemble tracing with callbacks
+# title: Single tracing with additional diagnostics
 # id: demo_savingcallback
 # date: 2023-12-17
 # author: "[Hongyang Zhou](https://github.com/henry2004y)"
 # julia: 1.9.4
-# description: Tracing multiple charged particles in a static EM field
+# description: Tracing one charged particle with additional diagnostics
 # ---
 
-# This example demonstrates tracing multiple protons in an analytic E field and numerical B field.
+# This example demonstrates tracing one proton in an analytic E field and numerical B field.
 # It also combines one type of normalization using a reference velocity `U₀`, a reference magnetic field `B₀`, and an initial reference gyroradius `rL`.
 # One way to think of this is that a proton with initial perpendicular velocity `U₀` will gyrate with a radius `rL`.
-# Check [demo_ensemble](@ref demo_ensemble) for basic usages of the ensemble problem.
 # The `SavingCallback` from DiffEqCallbacks.jl can be used to save additional outputs for diagnosis. Here we save the magnetic field along the trajectory, together with the parallel velocity.
+# Note that `SavingCallback` is currently not compatible with ensemble problems; for multiple particle tracing with customized outputs, see [demo_output_func](@ref demo_output_func).
 
-import DisplayAs #hide
 using TestParticle
 using OrdinaryDiffEq
-using Meshes
 using StaticArrays
 using Statistics
 using LinearAlgebra
 using DiffEqCallbacks
-using CairoMakie
-CairoMakie.activate!(type = "png")
-
-"Set initial state for EnsembleProblem."
-function prob_func(prob, i, repeat)
-   B0 = prob.p[3](prob.u0)
-   B0 = normalize(B0)
-
-   Bperp1 = SA[0.0, -B0[3], B0[2]] |> normalize
-   Bperp2 = B0 × Bperp1 |> normalize
-
-   ## initial azimuthal angle
-   ϕ = 2π*rand()
-   ## initial pitch angle
-   θ = acos(0.5)
-
-   sinϕ, cosϕ = sincos(ϕ)
-   prob.u0[4:6] = @. (B0*cos(θ) + Bperp1*(sin(θ)*cosϕ) + Bperp2*(sin(θ)*sinϕ)) * U₀
-
-   prob
-end
 
 ## Analytical electric field
 E(x) = SA[0.0, 0.0, 0.0]
@@ -51,12 +28,6 @@ nx, ny, nz = 4, 6, 8
 x = range(-10.0, 10.0, length=nx)
 y = range(-10.0, 10.0, length=ny)
 z = range(-10.0, 10.0, length=nz)
-Δx = x[2] - x[1]
-Δy = y[2] - y[1]
-Δz = z[2] - z[1]
-
-grid = CartesianGrid((length(x)-1, length(y)-1, length(z)-1),
-   (x[1], y[1], z[1]), (Δx, Δy, Δz))
 
 ## Numerical magnetic field
 B = Array{Float32, 4}(undef, 3, nx, ny, nz)
@@ -76,14 +47,32 @@ const rL = 4.0
 
 ## By default User type assumes q=1, m=1
 ## bc=2 uses periodic boundary conditions
-param = prepare(grid, E, B, Ω; species=User, bc=2)
+param = prepare(x, y, z, E, B, Ω; species=User, bc=2)
 
-x0 = [0.0, 0.0, 0.0] # initial position [l₀]
-u0 = [1U₀, 0.0, 0.0] # initial velocity [v₀]
-stateinit = [x0..., u0...]
 tspan = (0.0, 2π/Ω) # one averaged gyroperiod based on B₀
 
+## Dummy initial state
+stateinit = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
 prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
+
+prob.u0[4:6] = let
+   x0 = [0.0, 0.0, 0.0] # initial position [l₀]
+
+   B0 = prob.p[3](prob.u0)
+   B0 = normalize(B0)
+
+   Bperp1 = SA[0.0, -B0[3], B0[2]] |> normalize
+   Bperp2 = B0 × Bperp1 |> normalize
+
+   ## initial azimuthal angle
+   ϕ = 2π*rand()
+   ## initial pitch angle
+   θ = acos(0.5)
+
+   sinϕ, cosϕ = sincos(ϕ)
+   @. (B0*cos(θ) + Bperp1*(sin(θ)*cosϕ) + Bperp2*(sin(θ)*sinϕ)) * U₀
+end
 
 saved_values = SavedValues(Float64, Tuple{SVector{3, Float64}, Float64})
 
@@ -96,25 +85,8 @@ end
 
 cb = SavingCallback(save_B_mu, saved_values)
 
-## Number of trajectories
-trajectories = 2
+sol = solve(prob, Vern9(); callback=cb)
 
-ensemble_prob = EnsembleProblem(prob; prob_func, safetycopy=false)
-sols = solve(ensemble_prob, Vern9(), EnsembleThreads(); trajectories, callback=cb)
+# The extra values are saved in `saved_values`:
 
-## Visualization
-
-f = Figure(fontsize = 18)
-ax = Axis3(f[1, 1],
-   title = "Proton trajectories",
-   xlabel = "X",
-   ylabel = "Y",
-   zlabel = "Z",
-   aspect = :data,
-)
-
-for i in eachindex(sols)
-   lines!(ax, sols[i], label="$i")
-end
-
-f = DisplayAs.PNG(f) #hide
+saved_values


### PR DESCRIPTION
Unfortunately, `SavingCallback` from DiffEqCallbacks.jl does not seem to be compatible with `EnsembleProblem`. For ensemble problems, we can work around this issue by using the `output_func` argument.