### PR TITLE
Fix dimensionless tracing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestParticle"
 uuid = "953b605b-f162-4481-8f7f-a191c2bb40e3"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>, and Tiancheng Liu <liutc@mail.nankai.edu.cn>"]
-version = "0.5.2"
+version = "0.6.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestParticle"
 uuid = "953b605b-f162-4481-8f7f-a191c2bb40e3"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>, and Tiancheng Liu <liutc@mail.nankai.edu.cn>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -55,7 +55,7 @@ prob_boris = let dt = 1/7, paramBoris = BorisMethod(param_numeric)
 end
 SUITE["trace"]["numerical field"]["in place"] = @benchmarkable solve($prob_ip, Tsit5(); save_idxs=[1,2,3])
 SUITE["trace"]["numerical field"]["out of place"] = @benchmarkable solve($prob_oop, Tsit5(); save_idxs=[1,2,3])
-SUITE["trace"]["numerical field"]["Boris"] = @benchmarkable trace_trajectory($prob; savestepinterval=10)
+SUITE["trace"]["numerical field"]["Boris"] = @benchmarkable trace_trajectory($prob_boris; savestepinterval=10)
 
 param_td = prepare(E_td, B_td, F_td)
 prob_ip = ODEProblem(trace!, stateinit, tspan, param_td) # in place

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -50,8 +50,12 @@ SUITE["trace"]["analytic field"]["out of place"] = @benchmarkable solve($prob_oo
 param_numeric = prepare(mesh, E_numeric, B_numeric)
 prob_ip = ODEProblem(trace!, stateinit, tspan, param_numeric) # in place
 prob_oop = ODEProblem(trace, SA[stateinit...], tspan, param_numeric) # out of place
+prob_boris = let dt = 1/7, paramBoris = BorisMethod(param_numeric)
+    TraceProblem(stateinit, tspan, dt, paramBoris)
+end
 SUITE["trace"]["numerical field"]["in place"] = @benchmarkable solve($prob_ip, Tsit5(); save_idxs=[1,2,3])
 SUITE["trace"]["numerical field"]["out of place"] = @benchmarkable solve($prob_oop, Tsit5(); save_idxs=[1,2,3])
+SUITE["trace"]["numerical field"]["Boris"] = @benchmarkable trace_trajectory($prob; savestepinterval=10)
 
 param_td = prepare(E_td, B_td, F_td)
 prob_ip = ODEProblem(trace!, stateinit, tspan, param_td) # in place

--- a/docs/examples/basics/demo_dimensionless.jl
+++ b/docs/examples/basics/demo_dimensionless.jl
@@ -23,11 +23,11 @@ using OrdinaryDiffEq
 using CairoMakie
 CairoMakie.activate!(type = "png")
 
-x = range(-10, 10, length=15)
-y = range(-10, 10, length=20)
-z = range(-10, 10, length=25)
-B = fill(0.0, 3, length(x), length(y), length(z)) # [B₀]
-E = fill(0.0, 3, length(x), length(y), length(z)) # [E₀]
+## Number of cells for the field along each dimension
+nx, ny, nx = 4, 6, 8
+
+B = fill(0.0, 3, nx, ny, nz) # [B₀]
+E = fill(0.0, 3, nx, ny, nz) # [E₀]
 
 B[3,:,:,:] .= 10e-9
 ## Unit conversion factors
@@ -40,6 +40,10 @@ t₀ = 1 / Ω  # [s]
 U₀ = 1.0    # [m/s]
 l₀ = U₀ * t₀ # [m]
 E₀ = U₀*B₀ # [V/m]
+
+x = range(-10, 10, length=nx) # [l₀]
+y = range(-10, 10, length=ny) # [l₀]
+z = range(-10, 10, length=nz) # [l₀]
 
 ## For full EM problems, the normalization of E and B should be done separately.
 B ./= B₀

--- a/docs/examples/basics/demo_dimensionless.jl
+++ b/docs/examples/basics/demo_dimensionless.jl
@@ -24,7 +24,7 @@ using CairoMakie
 CairoMakie.activate!(type = "png")
 
 ## Number of cells for the field along each dimension
-nx, ny, nx = 4, 6, 8
+nx, ny, nz = 4, 6, 8
 
 B = fill(0.0, 3, nx, ny, nz) # [B₀]
 E = fill(0.0, 3, nx, ny, nz) # [E₀]

--- a/docs/examples/basics/demo_dimensionless.jl
+++ b/docs/examples/basics/demo_dimensionless.jl
@@ -8,11 +8,13 @@
 # ---
 
 # This example shows how to trace charged particles in dimensionless units.
-# After normalization, ``q=1, B=1, m=1`` so that the gyroradius `r_L = mv_\perp/qB = v_\perp`.
-# If the magnetic field is homogeneous and the initial perpendicular velocity is 4 (in the normalized units), then the gyroradius is 4 (in the normalized units).
+# After normalization, ``q=1, B=1, m=1`` so that the gyroradius `r_L = mv_\perp/qB = v_\perp`. All the quantities are given in dimensionless units.
+# If the magnetic field is homogeneous and the initial perpendicular velocity is 4, then the gyroradius is 4.
 # To convert them to the original units, ``v_\perp = 4*U_0`` and ``r_L = 4*l_0``.
+# Check [Demo: single tracing with additional diagnostics](@ref demo_savingcallback) for explaining the unit conversion.
+
 # Tracing in dimensionless units is beneficial for many scenarios. For example, MHD simulations do not have intrinsic scales. Therefore, we can do dimensionless particle tracing in MHD fields, and then convert to any scale we would like.
-#
+
 # Now let's demonstrate this with `trace_normalized!`.
 
 import DisplayAs #hide
@@ -25,29 +27,21 @@ CairoMakie.activate!(type = "png")
 
 ## Number of cells for the field along each dimension
 nx, ny, nz = 4, 6, 8
-
-B = fill(0.0, 3, nx, ny, nz) # [B₀]
-E = fill(0.0, 3, nx, ny, nz) # [E₀]
-
-B[3,:,:,:] .= 10e-9
-## Unit conversion factors
-B₀ = let Bmag = @views hypot.(B[1,:,:,:], B[2,:,:,:], B[3,:,:,:])
-   sqrt(sum(vec(Bmag) .^ 2)/length(Bmag))
-end
-
-Ω = abs(qᵢ) * B₀ / mᵢ
-t₀ = 1 / Ω  # [s]
-U₀ = 1.0    # [m/s]
-l₀ = U₀ * t₀ # [m]
-E₀ = U₀*B₀ # [V/m]
-
+## Unit conversion factors between SI and dimensionless units
+B₀ = 10e-9            # [T]
+Ω = abs(qᵢ) * B₀ / mᵢ # [1/s]
+t₀ = 1 / Ω            # [s]
+U₀ = 1.0              # [m/s]
+l₀ = U₀ * t₀          # [m]
+E₀ = U₀*B₀            # [V/m]
+## All quantities are in dimensionless units
 x = range(-10, 10, length=nx) # [l₀]
 y = range(-10, 10, length=ny) # [l₀]
 z = range(-10, 10, length=nz) # [l₀]
 
-## For full EM problems, the normalization of E and B should be done separately.
-B ./= B₀
-E ./= E₀
+B = fill(0.0, 3, nx, ny, nz) # [B₀]
+B[3,:,:,:] .= 1.0
+E = fill(0.0, 3, nx, ny, nz) # [E₀]
 
 param = prepare(x, y, z, E, B; species=User)
 

--- a/docs/examples/basics/demo_dimensionless_dimensional.jl
+++ b/docs/examples/basics/demo_dimensionless_dimensional.jl
@@ -66,14 +66,14 @@ prob1 = ODEProblem(trace!, stateinit1, tspan1, param1)
 sol1 = solve(prob1, Vern9(); reltol=1e-4, abstol=1e-6)
 
 ### Solving in dimensionless units
-B_normalize(x) = SA[0, 0, 1.0]
+B_normalize(x) = SA[0, 0, 1.0] # B₀/B₀
 E_normalize(x) = SA[Emag/E₀, 0.0, 0.0]
-## Default User type has q=1, m=1. Here we also set B=0. 
-param2 = prepare(E_normalize, B_normalize, 1.0; species=User)
+## For full EM problems, the normalization of E and B should be done separately.
+param2 = prepare(E_normalize, B_normalize; species=User)
 ## Scale initial quantities by the conversion factors
 x0 ./= l₀
 v0 ./= U₀
-tspan2 = (0, 2π/Ω/t₀)
+tspan2 = (0, 2π)
 stateinit2 = [x0..., v0...]
 
 prob2 = ODEProblem(trace_normalized!, stateinit2, tspan2, param2)

--- a/docs/examples/basics/demo_dimensionless_dimensional.jl
+++ b/docs/examples/basics/demo_dimensionless_dimensional.jl
@@ -43,15 +43,15 @@ using StaticArrays
 using CairoMakie
 CairoMakie.activate!(type = "png")
 
-## Unit conversion factors
-const B₀ = 1e-8 # [T]
-const U₀ = c    # [m/s]
-const E₀ = U₀*B₀ # [V/m]
-const Ω = abs(qᵢ) * B₀ / mᵢ
-const t₀ = 1 / Ω  # [s]
-const l₀ = U₀ * t₀ # [m]
-
-const Emag = 1e-8 # [V/m]
+## Unit conversion factors between SI and dimensionless units
+const B₀ = 1e-8             # [T]
+const U₀ = c                # [m/s]
+const E₀ = U₀*B₀            # [V/m]
+const Ω = abs(qᵢ) * B₀ / mᵢ # [1/s]
+const t₀ = 1 / Ω            # [s]
+const l₀ = U₀ * t₀          # [m]
+## Electric field magnitude in SI units
+const Emag = 1e-8           # [V/m]
 ### Solving in SI units
 B(x) = SA[0, 0, B₀]
 E(x) = SA[Emag, 0.0, 0.0]
@@ -59,14 +59,14 @@ E(x) = SA[Emag, 0.0, 0.0]
 x0 = [0.0, 0.0, 0.0] # [m]
 v0 = [0.0, 0.01c, 0.0] # [m/s]
 stateinit1 = [x0..., v0...]
-tspan1 = (0, 2π/Ω) # [s]
+tspan1 = (0, 2π*t₀) # [s]
 
 param1 = prepare(E, B, species=Proton)
 prob1 = ODEProblem(trace!, stateinit1, tspan1, param1)
 sol1 = solve(prob1, Vern9(); reltol=1e-4, abstol=1e-6)
 
 ### Solving in dimensionless units
-B_normalize(x) = SA[0, 0, 1.0] # B₀/B₀
+B_normalize(x) = SA[0, 0, B₀/B₀]
 E_normalize(x) = SA[Emag/E₀, 0.0, 0.0]
 ## For full EM problems, the normalization of E and B should be done separately.
 param2 = prepare(E_normalize, B_normalize; species=User)

--- a/docs/examples/basics/demo_dimensionless_periodic.jl
+++ b/docs/examples/basics/demo_dimensionless_periodic.jl
@@ -7,8 +7,8 @@
 # description: Tracing charged particle in dimensionless units and periodic boundary
 # ---
 
-# This example shows how to trace charged particles in dimensionless units and EM fields with periodic boundaries.
-# For details about dimensionless units, please check another [example](@ref demo_dimensionless).
+# This example shows how to trace charged particles in dimensionless units and EM fields with periodic boundaries in a 2D spatial domain.
+# For details about dimensionless units, please check [Demo: dimensionless tracing](@ref demo_dimensionless).
 
 # Now let's demonstrate this with `trace_normalized!`.
 
@@ -16,31 +16,27 @@ import DisplayAs #hide
 using TestParticle
 using TestParticle: qᵢ, mᵢ
 using OrdinaryDiffEq
-using Meshes
 using StaticArrays
 using CairoMakie
 CairoMakie.activate!(type = "png")
 
 ## Number of cells for the field along each dimension
 nx, ny = 4, 6
-
-B = fill(0.0, 3, nx, ny) # [B₀]
-B[3,:,:] .= 10e-9
-## Reference values for unit conversions
-## This is the magnitude of B
-B₀ = 10e-9 # [nT]
-Ω = abs(qᵢ) * B₀ / mᵢ
-t₀ = 1 / Ω  # [s]
-U₀ = 1.0    # [m/s]
-l₀ = U₀ * t₀ # [m]
-E₀ = U₀*B₀ # [V/m]
+## Unit conversion factors between SI and dimensionless units
+B₀ = 10e-9            # [T]
+Ω = abs(qᵢ) * B₀ / mᵢ # [1/s]
+t₀ = 1 / Ω            # [s]
+U₀ = 1.0              # [m/s]
+l₀ = U₀ * t₀          # [m]
+E₀ = U₀*B₀            # [V/m]
 
 x = range(-10, 10, length=nx) # [l₀]
 y = range(-10, 10, length=ny) # [l₀]
 
-## For full EM problems, the normalization of E and B should be done separately.
-B ./= B₀
-E(x) = SA[0.0/E₀, 0.0/E₀, 0.0/E₀]
+B = fill(0.0, 3, nx, ny) # [B₀]
+B[3,:,:] .= 1.0
+
+E(x) = SA[0.0, 0.0, 0.0] # [E₀]
 
 ## If bc == 1, we set a NaN value outside the domain (default);
 ## If bc == 2, we set periodic boundary conditions.
@@ -49,7 +45,7 @@ param = prepare(x, y, E, B; species=User, bc=2)
 # Note that we set a radius of 10, so the trajectory extent from -20 to 0 in y, which is beyond the original y range.
 
 x0 = [0.0, 0.0, 0.0] # initial position [l₀]
-u0 = [10, 0.0, 0.0] # initial velocity [v₀]
+u0 = [10.0, 0.0, 0.0] # initial velocity [v₀]
 stateinit = [x0..., u0...]
 tspan = (0.0, 1.5π) # 3/4 gyroperiod
 

--- a/docs/examples/basics/demo_dimensionless_periodic.jl
+++ b/docs/examples/basics/demo_dimensionless_periodic.jl
@@ -14,6 +14,7 @@
 
 import DisplayAs #hide
 using TestParticle
+using TestParticle: qᵢ, mᵢ
 using OrdinaryDiffEq
 using Meshes
 using StaticArrays
@@ -24,30 +25,30 @@ x = range(-10, 10, length=15)
 y = range(-10, 10, length=20)
 B = fill(0.0, 3, length(x), length(y)) # [B₀]
 
-E(x) = SA[0.0, 0.0, 0.0]
+B[3,:,:] .= 10e-9
+## This is the magnitude of B
+B₀ = 10e-9 # [nT]
 
-B₀ = 10e-9
+Ω = abs(qᵢ) * B₀ / mᵢ
+t₀ = 1 / Ω  # [s]
+U₀ = 1.0    # [m/s]
+l₀ = U₀ * t₀ # [m]
+E₀ = U₀*B₀ # [V/m]
 
-B[3,:,:] .= 1.0
-
-Δx = x[2] - x[1]
-Δy = y[2] - y[1]
-
-grid = CartesianGrid((length(x)-1, length(y)-1), (x[1], y[1]), (Δx, Δy))
+## For full EM problems, the normalization of E and B should be done separately.
+B ./= B₀
+E(x) = SA[0.0/E₀, 0.0/E₀, 0.0/E₀]
 
 ## If bc == 1, we set a NaN value outside the domain (default);
 ## If bc == 2, we set periodic boundary conditions.
-param = prepare(grid, E, B, B₀; species=Proton, bc=2)
-
-Ω = param[1]
-U₀ = 1.0
+param = prepare(E, B; species=User, bc=2)
 
 # Note that we set a radius of 10, so the trajectory extent from -20 to 0 in y, which is beyond the original y range.
 
 x0 = [0.0, 0.0, 0.0] # initial position [l₀]
-u0 = [10*Ω*U₀, 0.0, 0.0] # initial velocity [v₀]
+u0 = [10, 0.0, 0.0] # initial velocity [v₀]
 stateinit = [x0..., u0...]
-tspan = (0.0, 1.5π/Ω) # 3/4 gyroperiod
+tspan = (0.0, 1.5π) # 3/4 gyroperiod
 
 prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
 sol = solve(prob, Vern9())

--- a/docs/examples/basics/demo_dimensionless_periodic.jl
+++ b/docs/examples/basics/demo_dimensionless_periodic.jl
@@ -41,7 +41,7 @@ E(x) = SA[0.0/E₀, 0.0/E₀, 0.0/E₀]
 
 ## If bc == 1, we set a NaN value outside the domain (default);
 ## If bc == 2, we set periodic boundary conditions.
-param = prepare(E, B; species=User, bc=2)
+param = prepare(x, y, E, B; species=User, bc=2)
 
 # Note that we set a radius of 10, so the trajectory extent from -20 to 0 in y, which is beyond the original y range.
 

--- a/docs/examples/basics/demo_dimensionless_periodic.jl
+++ b/docs/examples/basics/demo_dimensionless_periodic.jl
@@ -21,10 +21,10 @@ using StaticArrays
 using CairoMakie
 CairoMakie.activate!(type = "png")
 
-x = range(-10, 10, length=15)
-y = range(-10, 10, length=20)
-B = fill(0.0, 3, length(x), length(y)) # [B₀]
+## Number of cells for the field along each dimension
+nx, ny = 4, 6
 
+B = fill(0.0, 3, nx, ny) # [B₀]
 B[3,:,:] .= 10e-9
 ## Reference values for unit conversions
 ## This is the magnitude of B
@@ -34,6 +34,9 @@ t₀ = 1 / Ω  # [s]
 U₀ = 1.0    # [m/s]
 l₀ = U₀ * t₀ # [m]
 E₀ = U₀*B₀ # [V/m]
+
+x = range(-10, 10, length=nx) # [l₀]
+y = range(-10, 10, length=ny) # [l₀]
 
 ## For full EM problems, the normalization of E and B should be done separately.
 B ./= B₀

--- a/docs/examples/basics/demo_dimensionless_periodic.jl
+++ b/docs/examples/basics/demo_dimensionless_periodic.jl
@@ -26,9 +26,9 @@ y = range(-10, 10, length=20)
 B = fill(0.0, 3, length(x), length(y)) # [B₀]
 
 B[3,:,:] .= 10e-9
+## Reference values for unit conversions
 ## This is the magnitude of B
 B₀ = 10e-9 # [nT]
-
 Ω = abs(qᵢ) * B₀ / mᵢ
 t₀ = 1 / Ω  # [s]
 U₀ = 1.0    # [m/s]

--- a/docs/examples/basics/demo_output_func.jl
+++ b/docs/examples/basics/demo_output_func.jl
@@ -10,6 +10,7 @@
 # This example demonstrates tracing multiple protons in an analytic E field and numerical B field.
 # See [Demo: single tracing with additional diagnostics](@ref demo_savingcallback) for explaining the unit conversion.
 # Also check [demo_ensemble](@ref demo_ensemble) for basic usages of the ensemble problem.
+
 # The `output_func` argument can be used to change saving outputs. It works as a reduction function, but here we demonstrate how to add additional outputs.
 # Besides the regular outputs, we also save the magnetic field along the trajectory, together with the parallel velocity.
 
@@ -48,26 +49,24 @@ end
 
 ## Number of cells for the field along each dimension
 nx, ny, nz = 4, 6, 8
-## Numerical magnetic field
+## Numerical magnetic field given in customized dimensionless units
 B = Array{Float32, 4}(undef, 3, nx, ny, nz)
 
 B[1,:,:,:] .= 0.0
 B[2,:,:,:] .= 0.0
 B[3,:,:,:] .= 2.0
 
-## Reference values for unit conversions
-const B₀ = let Bmag = @views hypot.(B[1,:,:,:], B[2,:,:,:], B[3,:,:,:])
-   sqrt(mean(vec(Bmag) .^ 2))
-end
+## Reference values for unit conversions between the customized and default dimensionless
+## units
+const B₀ = 2.0 
+const Ω = B₀
+const t₀ = 1 / Ω
+const U₀ = 1.0
+const l₀ = U₀ * t₀
+const E₀ = U₀ * B₀
 
-const Ω = abs(qᵢ) * B₀ / mᵢ
-const t₀ = 1 / Ω  # [s]
-const U₀ = 1.0    # [m/s]
-const l₀ = U₀ * t₀ # [m]
-const E₀ = U₀*B₀ # [V/m]
-
-## The original coordinates may have units. Divided by l₀ to convert to dimensionless unit.
-## Dimensionless spatial extent along each dimension
+## Convert from customized to default dimensionless units
+## Dimensionless spatial extent along each dimension with resolution 1
 x = range(0, nx-1, length=nx)
 y = range(0, ny-1, length=ny)
 z = range(0, nz-1, length=nz)

--- a/docs/examples/basics/demo_output_func.jl
+++ b/docs/examples/basics/demo_output_func.jl
@@ -49,35 +49,31 @@ end
 
 ## Number of cells for the field along each dimension
 nx, ny, nz = 4, 6, 8
-## Numerical magnetic field given in customized dimensionless units
+## Spatial coordinates given in customized units
+x = range(0, 1, length=nx)
+y = range(0, 1, length=ny)
+z = range(0, 1, length=nz)
+## Numerical magnetic field given in customized units
 B = Array{Float32, 4}(undef, 3, nx, ny, nz)
 
 B[1,:,:,:] .= 0.0
 B[2,:,:,:] .= 0.0
 B[3,:,:,:] .= 2.0
 
-## Reference values for unit conversions between the customized and default dimensionless
-## units
-const B₀ = 2.0 
-const Ω = B₀
-const t₀ = 1 / Ω
+## Reference values for unit conversions between the customized and dimensionless units
+const B₀ = let Bmag = @views hypot.(B[1,:,:,:], B[2,:,:,:], B[3,:,:,:])
+   sqrt(mean(vec(Bmag) .^ 2))
+end
 const U₀ = 1.0
-const l₀ = U₀ * t₀
+const l₀ = 2*nx
+const t₀ = l₀ / U₀
 const E₀ = U₀ * B₀
 
-## Convert from customized to default dimensionless units
-## Dimensionless spatial extent along each dimension with resolution 1
-x = range(0, nx-1, length=nx)
-y = range(0, ny-1, length=ny)
-z = range(0, nz-1, length=nz)
-## Factor to scale the spatial coordinates
-lscale = 2.0
-## Scale the coordinates to control the number of discrete B values encountered
-## along a given trajectory. In this case B is uniform, so it won't affect the result.
-x /= lscale
-y /= lscale
-z /= lscale
-
+### Convert from customized to default dimensionless units
+## Dimensionless spatial extents [l₀]
+x /= l₀
+y /= l₀
+z /= l₀
 ## For full EM problems, the normalization of E and B should be done separately.
 B ./= B₀
 E(x) = SA[0.0/E₀, 0.0/E₀, 0.0/E₀]

--- a/docs/examples/basics/demo_output_func.jl
+++ b/docs/examples/basics/demo_output_func.jl
@@ -15,6 +15,7 @@
 
 import DisplayAs #hide
 using TestParticle
+using TestParticle: qᵢ, mᵢ
 using OrdinaryDiffEq
 using StaticArrays
 using Statistics
@@ -47,11 +48,6 @@ end
 
 ## Number of cells for the field along each dimension
 nx, ny, nz = 4, 6, 8
-## Spatial extent along each dimension
-x = range(-0.5, 0.5, length=nx)
-y = range(-0.5, 0.5, length=ny)
-z = range(-0.5, 0.5, length=nz)
-
 ## Numerical magnetic field
 B = Array{Float32, 4}(undef, 3, nx, ny, nz)
 
@@ -69,6 +65,12 @@ const t₀ = 1 / Ω  # [s]
 const U₀ = 1.0    # [m/s]
 const l₀ = U₀ * t₀ # [m]
 const E₀ = U₀*B₀ # [V/m]
+
+## The original coordinates may have units. Divided by l₀ to convert to dimensionless unit.
+## Dimensionless spatial extent along each dimension
+x = range(0, nx-1, length=nx)
+y = range(0, ny-1, length=ny)
+z = range(0, nz-1, length=nz)
 ## Factor to scale the spatial coordinates
 lscale = 2.0
 ## Scale the coordinates to control the number of discrete B values encountered

--- a/docs/examples/basics/demo_savingcallback.jl
+++ b/docs/examples/basics/demo_savingcallback.jl
@@ -16,7 +16,7 @@
 # MHD models, for instance, are dimensionless by nature.
 # If we simulate a turbulence field with MHD, we want to include more discrete points within a gyro-radius for the effect of small scale perturbations to take place. (Otherwise within one gyro-period all you will see is a nice-looking helix!)
 # However, we cannot simply shrink the spatial coordinates as we wish, otherwise we will quickly encounter the boundary of our simulation.
-#
+
 # The `SavingCallback` from DiffEqCallbacks.jl can be used to save additional outputs for diagnosis. Here we save the magnetic field along the trajectory, together with the parallel velocity.
 # Note that `SavingCallback` is currently not compatible with ensemble problems; for multiple particle tracing with customized outputs, see [Demo: ensemble tracing with extra saving](@ref demo_output_func).
 
@@ -30,25 +30,24 @@ using DiffEqCallbacks
 
 ## Number of cells for the field along each dimension
 nx, ny, nz = 4, 6, 8
-## Numerical magnetic field
+## Numerical magnetic field given in customized dimensionless units
 B = Array{Float32, 4}(undef, 3, nx, ny, nz)
 
 B[1,:,:,:] .= 0.0
 B[2,:,:,:] .= 0.0
 B[3,:,:,:] .= 2.0
-## Reference values for unit conversions
-const B₀ = let Bmag = @views hypot.(B[1,:,:,:], B[2,:,:,:], B[3,:,:,:])
-   sqrt(mean(vec(Bmag) .^ 2))
-end
 
-const Ω = abs(qᵢ) * B₀ / mᵢ
-const t₀ = 1 / Ω  # [s]
-const U₀ = 1.0    # [m/s]
-const l₀ = U₀ * t₀ # [m]
-const E₀ = U₀*B₀ # [V/m]
+## Reference values for unit conversions between the customized and default dimensionless
+## units
+const B₀ = 2.0 
+const Ω = B₀
+const t₀ = 1 / Ω
+const U₀ = 1.0
+const l₀ = U₀ * t₀
+const E₀ = U₀ * B₀
 
-## The original coordinates may have units. Divided by l₀ to convert to dimensionless unit.
-## Dimensionless spatial extent along each dimension
+## Convert from customized to default dimensionless units
+## Dimensionless spatial extent along each dimension with resolution 1
 x = range(0, nx-1, length=nx)
 y = range(0, ny-1, length=ny)
 z = range(0, nz-1, length=nz)

--- a/docs/examples/basics/demo_savingcallback.jl
+++ b/docs/examples/basics/demo_savingcallback.jl
@@ -10,6 +10,13 @@
 # This example demonstrates tracing one proton in an analytic E field and numerical B field.
 # It also combines one type of normalization using a reference velocity `U₀`, a reference magnetic field `B₀`, and a reference time `1/Ω`, where `Ω` is the gyrofrequency.
 # This indicates that in the dimensionless units, a proton with initial perpendicular velocity 1 will possess a gyro-radius of 1.
+# In the dimensionless spatial coordinates, we can zoom in/out the EM field to control the number of discrete points encountered in a gyroperiod.
+# For example, if `dx=dy=dz=1`, it means that a particle with perpendicular velocity 1 will "see" one discrete point along a certain direction oriented from the gyro-center within the gyro-radius;
+# if `dx=dy=dz=0.5`, then the particle will "see" two discrete points.
+# MHD models, for instance, are dimensionless by nature.
+# If we simulate a turbulence field with MHD, we want to include more discrete points within a gyro-radius for the effect of small scale perturbations to take place. (Otherwise within one gyro-period all you will see is a nice-looking helix!)
+# However, we cannot simply shrink the spatial coordinates as we wish, otherwise we will quickly encounter the boundary of our simulation.
+#
 # The `SavingCallback` from DiffEqCallbacks.jl can be used to save additional outputs for diagnosis. Here we save the magnetic field along the trajectory, together with the parallel velocity.
 # Note that `SavingCallback` is currently not compatible with ensemble problems; for multiple particle tracing with customized outputs, see [Demo: ensemble tracing with extra saving](@ref demo_output_func).
 
@@ -23,11 +30,6 @@ using DiffEqCallbacks
 
 ## Number of cells for the field along each dimension
 nx, ny, nz = 4, 6, 8
-## Spatial extent along each dimension
-x = range(-0.5, 0.5, length=nx)
-y = range(-0.5, 0.5, length=ny)
-z = range(-0.5, 0.5, length=nz)
-
 ## Numerical magnetic field
 B = Array{Float32, 4}(undef, 3, nx, ny, nz)
 
@@ -44,6 +46,12 @@ const t₀ = 1 / Ω  # [s]
 const U₀ = 1.0    # [m/s]
 const l₀ = U₀ * t₀ # [m]
 const E₀ = U₀*B₀ # [V/m]
+
+## The original coordinates may have units. Divided by l₀ to convert to dimensionless unit.
+## Dimensionless spatial extent along each dimension
+x = range(0, nx-1, length=nx)
+y = range(0, ny-1, length=ny)
+z = range(0, nz-1, length=nz)
 ## Factor to scale the spatial coordinates
 lscale = 2.0
 ## Scale the coordinates to control the number of discrete B values encountered


### PR DESCRIPTION
Treat dimensionless tracing in a consistent manner. Although the previous version partially works, it's so easy to confuse ourselves about the input and output units. Instead of relying on one single normalization factor for the pure-B tracing cases, we should instead normalize E and B fields separately. The updated `prepare` function can be simplified with the "correct" normalization process. `trace_normalized!` is actually simpler since all the normalizations are embedded inside E and B fields.