### PR TITLE
Refactor Boris ensemble tracing

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -56,6 +56,7 @@ end
 SUITE["trace"]["numerical field"]["in place"] = @benchmarkable solve($prob_ip, Tsit5(); save_idxs=[1,2,3])
 SUITE["trace"]["numerical field"]["out of place"] = @benchmarkable solve($prob_oop, Tsit5(); save_idxs=[1,2,3])
 SUITE["trace"]["numerical field"]["Boris"] = @benchmarkable trace_trajectory($prob_boris; savestepinterval=10)
+SUITE["trace"]["numerical field"]["Boris ensemble"] = @benchmarkable trace_trajectory($prob_boris; savestepinterval=10, trajectories=2)
 
 param_td = prepare(E_td, B_td, F_td)
 prob_ip = ODEProblem(trace!, stateinit, tspan, param_td) # in place

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -130,16 +130,16 @@ function trace_trajectory(prob::TraceProblem; trajectories::Int=1,
    savestepinterval::Int=1, isoutofdomain::Function=ODE_DEFAULT_ISOUTOFDOMAIN)
 
    sols = Vector{TraceSolution}(undef, trajectories)
+   # prepare advancing
    xv = similar(prob.u0)
    (; tspan, dt, p) = prob
-
-   # prepare advancing
    ttotal = tspan[2] - tspan[1]
    nt = Int(ttotal ÷ dt)
    iout, nout = 1, nt ÷ savestepinterval + 1
    traj = zeros(eltype(prob.u0), 6, nout)
 
    for i in 1:trajectories
+      # set initial conditions for each trajectory
       new_prob = prob.prob_func(prob, i, false)
       xv .= new_prob.u0
       traj[:,1] = xv

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -173,6 +173,7 @@ function trace_trajectory(prob::TraceProblem; trajectories::Int=1,
          t = collect(range(tspan[1], tspan[1]+iout*dt, step=dt))
       end
       sols[i] = TraceSolution(traj_save, t)
+      iout = 1
    end
 
    sols


### PR DESCRIPTION
Current implementation of the Boris ensemble pusher triggers quite a lot memory allocations, which in turn triggers GC more frequently when running with multithreading (#127). This PR tries to reduce the allocations a bit by assuming that the timestep, EM fields, and particle properties are constant within one batch tracing.