### PR TITLE
Fix Maxwellian sampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.9.2"
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -19,7 +18,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChunkSplitters = "2"
-Distributions = "0.25"
 Elliptic = "1"
 Interpolations = "0.14, 0.15"
 Meshes = "0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestParticle"
 uuid = "953b605b-f162-4481-8f7f-a191c2bb40e3"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>, and Tiancheng Liu <liutc@mail.nankai.edu.cn>"]
-version = "0.9.2"
+version = "0.10.0"
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"

--- a/docs/examples/basics/demo_multiple.jl
+++ b/docs/examples/basics/demo_multiple.jl
@@ -3,7 +3,7 @@
 # id: demo_multiple
 # date: 2023-04-20
 # author: "[Hongyang Zhou](https://github.com/henry2004y)"
-# julia: 1.9.0
+# julia: 1.10.2
 # description: Tracing multiple charged particles in a static EM field
 # ---
 
@@ -31,11 +31,11 @@ function trace(x, y, z, E, B; trajectories::Int=10)
    sols = Vector{ODESolution}(undef, trajectories)
    ## Sample from a Maxwellian with bulk speed 0 and thermal speed 1.0
    vdf = Maxwellian([0.0, 0.0, 0.0], 1.0)
-   v = sample(vdf, trajectories)
+   v = [sample(vdf) for _ in 1:trajectories]
 
    for i in 1:trajectories
       #prob = remake(prob; u0=[x0..., v[:,i]...])
-      prob.u0[4:6] = v[:,i]
+      prob.u0[4:6] = v[i]
 
       sol = solve(prob, Vern9())
       sols[i] = sol

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -1,15 +1,15 @@
 module TestParticle
 
 using LinearAlgebra: norm, ×, ⋅
-using Meshes: coordinates, spacing, embeddim, CartesianGrid
+using Statistics: mean, normalize
 using Interpolations: interpolate, extrapolate, scale, BSpline, Linear, Quadratic, Cubic,
    Line, OnCell, Periodic, Flat
 using SciMLBase: AbstractODEProblem, AbstractODEFunction, AbstractODESolution, ReturnCode,
    BasicEnsembleAlgorithm, EnsembleThreads, EnsembleSerial,
    DEFAULT_SPECIALIZATION, ODEFunction, 
    LinearInterpolation
-using Distributions: MvNormal
-using StaticArrays
+using StaticArrays: SVector, @SMatrix, MVector, SA
+using Meshes: coordinates, spacing, embeddim, CartesianGrid
 using ChunkSplitters
 using PrecompileTools: @setup_workload, @compile_workload
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -20,8 +20,10 @@
          (x[1], y[1], z[1]),
          (Δx, Δy, Δz))
 
-      vdf = Maxwellian([0.0, 0.0, 0.0], 1.0)
-      v = sample(vdf, 2)
+      vdf = Maxwellian([0.0, 0.0, 0.0], 1e-9, 1e6)
+      v = sample(vdf)
+      vdf = BiMaxwellian([1.0, 0.0, 0.0], [0.0, 0.0, 0.0], 1e-9, 1e-9, 1e6)
+      v = sample(vdf)
       # numerical field
       param = prepare(x, y, z, E, B)
       param = prepare(mesh, E, B)

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -1,7 +1,5 @@
 # Collection of utility functions and commonly used constants.
 
-using Statistics: mean
-
 "Convert from spherical to Cartesian coordinates vector."
 function sph2cart(r, ϕ, θ)
    r*[sin(θ)*cos(ϕ), sin(θ)*sin(ϕ), cos(θ)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,16 +30,17 @@ end
 @testset "TestParticle.jl" begin
    @testset "sampling" begin
       u0 = [0.0, 0.0, 0.0]
-      uth = 1.0
-      vdf = Maxwellian(u0, uth)
+      p = 1e-9  # [Pa]
+      n = 1e6  # [/cc]
+      vdf = Maxwellian(u0, p, n)
       Random.seed!(1234)
-      v = sample(vdf, 2)
-      @test sum(v) == 0.5383742610785328
-      B = [1.0, 0.0, 0.0]
-      vdf = BiMaxwellian(u0, uth, uth, B)
+      v = sample(vdf)
+      @test sum(v) == 371365.50994738773
+      B = [1.0, 0.0, 0.0] # will be normalized internally
+      vdf = BiMaxwellian(B, u0, p, p, n)
       Random.seed!(1234)
-      v = sample(vdf, 2)
-      @test sum(v) == 0.5429092742594825
+      v = sample(vdf)
+      @test sum(v) == -961387.4020494563
    end
 
    @testset "numerical field" begin


### PR DESCRIPTION
Our current implementation of Maxwellian sampling is wrong. This PR fixes the sampling and improve the shock demo.
The new sampling is based on the Box-Muller method. We remove the option of `nparticles` inputs since it's less frequently used in practice, although it's supposed to be faster.

Since we are sampling in each 1D direction separately, we should follow the 1D thermal speed equation.

* Use `vth` for thermal speed instead of `uth`. 

#150