### PR TITLE
Fix time length mismatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestParticle"
 uuid = "953b605b-f162-4481-8f7f-a191c2bb40e3"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>, and Tiancheng Liu <liutc@mail.nankai.edu.cn>"]
-version = "0.10.3"
+version = "0.10.4"
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -217,16 +217,8 @@ function _boris!(sols, prob, irange, savestepinterval, dt, ttotal, nt, nout, iso
       end
 
       if iout == nout # regular termination
-         dtfinal = ttotal - nt*dt
-         if abs(dtfinal) > abs(0.5*dt) # final step if needed
-            update_velocity!(xv, paramBoris, p, dtfinal)
-            update_location!(xv, dtfinal)
-            traj_save = copy(traj)
-            push!(traj_save, u0)
-         else
-            traj_save = copy(traj)
-         end
-         t = [collect(tspan[1]:dt*savestepinterval:tspan[2])..., tspan[2]]
+         traj_save = copy(traj)
+         t = collect(tspan[1]:dt*savestepinterval:tspan[2])
       else # early termination or savestepinterval != 1
          traj_save = traj[1:iout]
          t = collect(tspan[1]:dt*savestepinterval:tspan[1]+dt*savestepinterval*(iout-1))

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -223,11 +223,10 @@ function _boris!(sols, prob, irange, savestepinterval, dt, ttotal, nt, nout, iso
             update_location!(xv, dtfinal)
             traj_save = copy(traj)
             push!(traj_save, u0)
-            t = [collect(tspan[1]:dt*savestepinterval:tspan[2])..., tspan[2]]
          else
             traj_save = copy(traj)
-            t = collect(tspan[1]:dt*savestepinterval:tspan[2])
          end
+         t = [collect(tspan[1]:dt*savestepinterval:tspan[2])..., tspan[2]]
       else # early termination or savestepinterval != 1
          traj_save = traj[1:iout]
          t = collect(tspan[1]:dt*savestepinterval:tspan[1]+dt*savestepinterval*(iout-1))


### PR DESCRIPTION
Fix an issue that causes an end point mismatch in the Boris pusher: we no longer force to have an exact end time at `tspan[2]`.