### PR TITLE
Bump meshes compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestParticle"
 uuid = "953b605b-f162-4481-8f7f-a191c2bb40e3"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>, and Tiancheng Liu <liutc@mail.nankai.edu.cn>"]
-version = "0.10.5"
+version = "0.10.6"
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
@@ -20,7 +20,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ChunkSplitters = "2"
 Elliptic = "1"
 Interpolations = "0.14, 0.15"
-Meshes = "0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.40, 0.41, 0.42, 0.43"
+Meshes = "0.43"
 PrecompileTools = "1"
 SciMLBase = "2.24"
 SpecialFunctions = "1.5, 2"

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -9,7 +9,7 @@ using SciMLBase: AbstractODEProblem, AbstractODEFunction, AbstractODESolution, R
    DEFAULT_SPECIALIZATION, ODEFunction, 
    LinearInterpolation
 using StaticArrays: SVector, @SMatrix, MVector, SA
-using Meshes: coordinates, spacing, embeddim, CartesianGrid
+using Meshes: coords, spacing, embeddim, CartesianGrid
 using ChunkSplitters
 using PrecompileTools: @setup_workload, @compile_workload
 

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -32,9 +32,9 @@ function makegrid(grid::CartesianGrid{3, T}) where T
    gridmax = coords(maximum(grid))
    Δx = spacing(grid)
 
-   gridx = range(gridmin[1], gridmax[1], step=Δx[1])
-   gridy = range(gridmin[2], gridmax[2], step=Δx[2])
-   gridz = range(gridmin[3], gridmax[3], step=Δx[3])
+   gridx = range(gridmin.x.val, gridmax.x.val, step=Δx[1].val)
+   gridy = range(gridmin.y.val, gridmax.y.val, step=Δx[2].val)
+   gridz = range(gridmin.z.val, gridmax.z.val, step=Δx[3].val)
 
    gridx, gridy, gridz
 end
@@ -44,8 +44,8 @@ function makegrid(grid::CartesianGrid{2, T}) where T
    gridmax = coords(maximum(grid))
    Δx = spacing(grid)
 
-   gridx = range(gridmin[1], gridmax[1], step=Δx[1])
-   gridy = range(gridmin[2], gridmax[2], step=Δx[2])
+   gridx = range(gridmin.x.val, gridmax.x.val, step=Δx[1].val)
+   gridy = range(gridmin.y.val, gridmax.y.val, step=Δx[2].val)
 
    gridx, gridy
 end

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -28,8 +28,8 @@ end
 
 "Return uniform range from 2D/3D CartesianGrid."
 function makegrid(grid::CartesianGrid{3, T}) where T
-   gridmin = coordinates(minimum(grid))
-   gridmax = coordinates(maximum(grid))
+   gridmin = coords(minimum(grid))
+   gridmax = coords(maximum(grid))
    Δx = spacing(grid)
 
    gridx = range(gridmin[1], gridmax[1], step=Δx[1])
@@ -40,8 +40,8 @@ function makegrid(grid::CartesianGrid{3, T}) where T
 end
 
 function makegrid(grid::CartesianGrid{2, T}) where T
-   gridmin = coordinates(minimum(grid))
-   gridmax = coordinates(maximum(grid))
+   gridmin = coords(minimum(grid))
+   gridmax = coords(maximum(grid))
    Δx = spacing(grid)
 
    gridx = range(gridmin[1], gridmax[1], step=Δx[1])


### PR DESCRIPTION
In Meshes.jl v0.43, `coordinates` is renamed to `coords`. Also, Units.jl is integrated into the type system, so there are quite many changes.