### PR TITLE
Split gc functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestParticle"
 uuid = "953b605b-f162-4481-8f7f-a191c2bb40e3"
 authors = ["Hongyang Zhou <hyzhou@umich.edu>, and Tiancheng Liu <liutc@mail.nankai.edu.cn>"]
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"

--- a/docs/examples/advanced/demo_gc.jl
+++ b/docs/examples/advanced/demo_gc.jl
@@ -65,7 +65,7 @@ prob_gc = ODEProblem(trace_gc_1st!, stateinit_gc, tspan, param_gc)
 sol_gc_numericBfield = solve(prob_gc, Vern9())
 
 ## analytical drifts
-gc = get_gc(param)
+gc = param |> get_gc_func
 gc_x0 = gc(stateinit)
 prob_gc_analytic = ODEProblem(trace_gc_drifts!, gc_x0, tspan, (param..., sol))
 sol_gc_analytic = solve(prob_gc_analytic, Vern9(); save_idxs=[1,2,3])
@@ -114,7 +114,7 @@ param = prepare(uniform_E, grad_B, species=Proton)
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 
-gc = get_gc(param)
+gc = param |> get_gc_func
 gc_x0 = gc(stateinit)
 prob_gc_analytic = ODEProblem(trace_gc_drifts!, gc_x0, tspan, (param..., sol))
 sol_gc_analytic = solve(prob_gc_analytic, Vern9(); save_idxs=[1,2,3])
@@ -153,7 +153,7 @@ param = prepare(uniform_E, grad_B, species=Proton)
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 
-gc = get_gc(param)
+gc = param |> get_gc_func
 gc_x0 = gc(stateinit)
 prob_gc_analytic = ODEProblem(trace_gc_drifts!, gc_x0, tspan, (param..., sol))
 sol_gc_analytic = solve(prob_gc_analytic, Vern9(); save_idxs=[1,2,3])

--- a/docs/examples/advanced/demo_gc.jl
+++ b/docs/examples/advanced/demo_gc.jl
@@ -66,7 +66,7 @@ sol_gc_numericBfield = solve(prob_gc, Vern9())
 
 ## analytical drifts
 gc = param |> get_gc_func
-gc_x0 = gc(stateinit)
+gc_x0 = gc(stateinit) |> Vector
 prob_gc_analytic = ODEProblem(trace_gc_drifts!, gc_x0, tspan, (param..., sol))
 sol_gc_analytic = solve(prob_gc_analytic, Vern9(); save_idxs=[1,2,3])
 
@@ -115,7 +115,7 @@ prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 
 gc = param |> get_gc_func
-gc_x0 = gc(stateinit)
+gc_x0 = gc(stateinit) |> Vector
 prob_gc_analytic = ODEProblem(trace_gc_drifts!, gc_x0, tspan, (param..., sol))
 sol_gc_analytic = solve(prob_gc_analytic, Vern9(); save_idxs=[1,2,3])
 
@@ -154,7 +154,7 @@ prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 
 gc = param |> get_gc_func
-gc_x0 = gc(stateinit)
+gc_x0 = gc(stateinit) |> Vector
 prob_gc_analytic = ODEProblem(trace_gc_drifts!, gc_x0, tspan, (param..., sol))
 sol_gc_analytic = solve(prob_gc_analytic, Vern9(); save_idxs=[1,2,3])
 

--- a/docs/examples/basics/demo_ExB_drift.jl
+++ b/docs/examples/basics/demo_ExB_drift.jl
@@ -45,7 +45,7 @@ prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 
 ## Functions for obtaining the guiding center from actual trajectory
-gc = get_gc(param)
+gc = param |> get_gc_func
 gc_x0 = gc(stateinit)
 prob_gc = ODEProblem(trace_gc_ExB!, gc_x0, tspan, (param..., sol))
 sol_gc = solve(prob_gc, Vern9(); save_idxs=[1,2,3]);

--- a/docs/examples/basics/demo_ExB_drift.jl
+++ b/docs/examples/basics/demo_ExB_drift.jl
@@ -46,7 +46,7 @@ sol = solve(prob, Vern9())
 
 ## Functions for obtaining the guiding center from actual trajectory
 gc = param |> get_gc_func
-gc_x0 = gc(stateinit)
+gc_x0 = gc(stateinit) |> Vector
 prob_gc = ODEProblem(trace_gc_ExB!, gc_x0, tspan, (param..., sol))
 sol_gc = solve(prob_gc, Vern9(); save_idxs=[1,2,3]);
 

--- a/docs/examples/basics/demo_FLR.jl
+++ b/docs/examples/basics/demo_FLR.jl
@@ -56,7 +56,7 @@ prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 
 gc = param |> get_gc_func
-gc_x0 = gc(stateinit)
+gc_x0 = gc(stateinit) |> Vector
 prob_gc = ODEProblem(trace_gc!, gc_x0, tspan, (param..., sol))
 sol_gc = solve(prob_gc, Vern7(); save_idxs=[1,2,3])
 

--- a/docs/examples/basics/demo_FLR.jl
+++ b/docs/examples/basics/demo_FLR.jl
@@ -55,7 +55,7 @@ param = prepare(nonuniform_E, uniform_B, species=Proton)
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 
-gc = get_gc(param)
+gc = param |> get_gc_func
 gc_x0 = gc(stateinit)
 prob_gc = ODEProblem(trace_gc!, gc_x0, tspan, (param..., sol))
 sol_gc = solve(prob_gc, Vern7(); save_idxs=[1,2,3])

--- a/docs/examples/basics/demo_curvature_B.jl
+++ b/docs/examples/basics/demo_curvature_B.jl
@@ -44,7 +44,7 @@ prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 ## Functions for obtaining the guiding center from actual trajectory
 gc = param |> get_gc_func
-gc_x0 = gc(stateinit)
+gc_x0 = gc(stateinit) |> Vector
 prob_gc = ODEProblem(trace_gc_drifts!, gc_x0, tspan, (param..., sol))
 sol_gc = solve(prob_gc, Vern7(); save_idxs=[1,2,3])
 

--- a/docs/examples/basics/demo_curvature_B.jl
+++ b/docs/examples/basics/demo_curvature_B.jl
@@ -43,7 +43,7 @@ param = prepare(zero_E, curved_B, species=Proton)
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 ## Functions for obtaining the guiding center from actual trajectory
-gc = get_gc(param)
+gc = param |> get_gc_func
 gc_x0 = gc(stateinit)
 prob_gc = ODEProblem(trace_gc_drifts!, gc_x0, tspan, (param..., sol))
 sol_gc = solve(prob_gc, Vern7(); save_idxs=[1,2,3])

--- a/docs/examples/basics/demo_gradient_B.jl
+++ b/docs/examples/basics/demo_gradient_B.jl
@@ -53,7 +53,7 @@ prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 ## Functions for obtaining the guiding center from actual trajectory
 gc = param |> get_gc_func
-gc_x0 = gc(stateinit)
+gc_x0 = gc(stateinit) |> Vector
 prob_gc = ODEProblem(trace_gc!, gc_x0, tspan, (param..., sol))
 sol_gc = solve(prob_gc, Vern7(); save_idxs=[1,2,3])
 

--- a/docs/examples/basics/demo_gradient_B.jl
+++ b/docs/examples/basics/demo_gradient_B.jl
@@ -52,7 +52,7 @@ param = prepare(uniform_E, grad_B, species=Proton)
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 ## Functions for obtaining the guiding center from actual trajectory
-gc = get_gc(param)
+gc = param |> get_gc_func
 gc_x0 = gc(stateinit)
 prob_gc = ODEProblem(trace_gc!, gc_x0, tspan, (param..., sol))
 sol_gc = solve(prob_gc, Vern7(); save_idxs=[1,2,3])

--- a/docs/examples/basics/demo_polarization_drift.jl
+++ b/docs/examples/basics/demo_polarization_drift.jl
@@ -34,7 +34,7 @@ param = prepare(time_varying_E, uniform_B, species=Proton)
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 ## Functions for obtaining the guiding center from actual trajectory
-gc = get_gc(param)
+gc = param |> get_gc_func
 v_perp(xu) = sqrt(xu[4]^2 + xu[5]^2)
 
 ## Visualization

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -14,7 +14,7 @@ using ForwardDiff
 using ChunkSplitters
 using PrecompileTools: @setup_workload, @compile_workload
 
-export prepare, prepare_gc, sample, get_gc
+export prepare, prepare_gc, sample, get_gc, get_gc_func
 export trace!, trace_relativistic!, trace_normalized!, trace_relativistic_normalized!,
 	trace, trace_relativistic, trace_relativistic_normalized, trace_gc!, trace_gc_1st!,
 	trace_gc_drifts!

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -11,7 +11,7 @@ ODE equations for charged particle moving in static EM field and external force 
 function trace!(dy, y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
 
-	v = @views SVector{3}(y[4:6])
+	v = y[SA[4:6...]]
 	E = SVector{3}(Efunc(y, t))
 	B = SVector{3}(Bfunc(y, t))
 
@@ -24,7 +24,7 @@ end
 function trace!(dy, y, p::FullTPTuple, t)
 	q, m, Efunc, Bfunc, Ffunc = p
 
-	v = @views SVector{3}(y[4:6])
+	v = y[SA[4:6...]]
 	E = SVector{3}(Efunc(y, t))
 	B = SVector{3}(Bfunc(y, t))
 	F = SVector{3}(Ffunc(y, t))
@@ -45,7 +45,7 @@ ODE equations for charged particle moving in static EM field and external force 
 """
 function trace(y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
-	v = @views SVector{3}(y[4:6])
+	v = y[SA[4:6...]]
 	E = SVector{3}(Efunc(y, t))
 	B = SVector{3}(Bfunc(y, t))
 
@@ -57,7 +57,7 @@ end
 function trace(y, p::FullTPTuple, t)
 	q, m, Efunc, Bfunc, Ffunc = p
 
-	v = @views SVector{3}(y[4:6])
+	v = y[SA[4:6...]]
 	E = SVector{3}(Efunc(y, t))
 	B = SVector{3}(Bfunc(y, t))
 	F = SVector{3}(Ffunc(y, t))
@@ -77,7 +77,7 @@ function trace_relativistic!(dy, y, p::TPTuple, t)
 	E = SVector{3}(Efunc(y, t))
 	B = SVector{3}(Bfunc(y, t))
 
-	γv = @views SVector{3, eltype(dy)}(y[4:6])
+	γv = y[SA[4:6...]]
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(dy))
 		v̂ = normalize(γv)
@@ -103,7 +103,7 @@ function trace_relativistic(y, p::TPTuple, t)
 	E = SVector{3}(Efunc(y, t))
 	B = SVector{3}(Bfunc(y, t))
 
-	γv = @views SVector{3, eltype(y)}(y[4:6])
+	γv = y[SA[4:6...]]
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(y))
 		v̂ = normalize(γv)
@@ -127,7 +127,7 @@ the extrapolation function provided by Interpolations.jl.
 function trace_normalized!(dy, y, p::TPNormalizedTuple, t)
 	_, Efunc, Bfunc = p
 
-	v = @views SVector{3}(y[4:6])
+	v = y[SA[4:6...]]
 	E = SVector{3}(Efunc(y, t))
 	B = SVector{3}(Bfunc(y, t))
 
@@ -146,7 +146,7 @@ function trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
 	_, Efunc, Bfunc = p
 	E = SVector{3}(Efunc(y, t))
 	B = SVector{3}(Bfunc(y, t))
-	γv = @views SVector{3}(y[4:6])
+	γv = y[SA[4:6...]]
 
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(dy))
@@ -172,7 +172,7 @@ function trace_relativistic_normalized(y, p::TPNormalizedTuple, t)
 	_, Efunc, Bfunc = p
 	E = SVector{3}(Efunc(y, t))
 	B = SVector{3}(Bfunc(y, t))
-	γv = @views SVector{3}(y[4:6])
+	γv = y[SA[4:6...]]
 
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(y))
@@ -196,7 +196,7 @@ Parallel velocity is also added. This expression requires the full particle traj
 function trace_gc_drifts!(dx, x, p, t)
 	q2m, Efunc, Bfunc, sol = p
 	xu = sol(t)
-	v = @views SVector{3, eltype(dx)}(xu[4:6])
+	v = xu[SA[4:6...]]
 	E = SVector{3}(Efunc(x))
 	B = SVector{3}(Bfunc(x))
 
@@ -222,7 +222,7 @@ Variable `y = (x, y, z, u)`, where `u` is the velocity along the magnetic field 
 function trace_gc!(dy, y, p::GCTuple, t)
 	q, m, μ, Efunc, Bfunc = p
 	q2m = q / m
-	X = @views SVector{3}(y[1:3])
+	X = y[SA[1:3...]]
 	E = SVector{3}(Efunc(X, t))
 	B = SVector{3}(Bfunc(X, t))
 	b̂ = normalize(B) # unit B field at X
@@ -259,7 +259,7 @@ end
 function trace_gc_1st!(dy, y, p::GCTuple, t)
 	q, m, μ, Efunc, Bfunc = p
 	q2m = q / m
-	X = @view y[1:3]
+	X = y[SA[1:3...]]
 	E = Efunc(X, t)
 	B = Bfunc(X, t)
 	b̂ = normalize(B) # unit B field at X

--- a/src/gc.jl
+++ b/src/gc.jl
@@ -6,7 +6,7 @@ function prepare_gc(xv, xrange::T, yrange::T, zrange::T, E::TE, B::TB;
 	bc::Int = 1, removeExB = true) where {T <: AbstractRange, TE, TB}
 
 	q, m = getchargemass(species, q, m)
-	x, v = @views xv[1:3], xv[4:6]
+	x, v = xv[SA[1:3...]], xv[SA[4:6...]]
 
 	E = TE <: AbstractArray ? getinterp(E, xrange, yrange, zrange, order, bc) : E
 	B = TB <: AbstractArray ? getinterp(B, xrange, yrange, zrange, order, bc) : B
@@ -42,7 +42,7 @@ end
 function prepare_gc(xv, E, B; species::Species = Proton, q::AbstractFloat = 1.0,
 	m::AbstractFloat = 1.0, removeExB = true)
 	q, m = getchargemass(species, q, m)
-	x, v = @views xv[1:3], xv[4:6]
+	x, v = xv[SA[1:3...]], xv[SA[4:6...]]
 
 	bparticle = B(x)
 	Bmag_particle = √(bparticle[1]^2 + bparticle[2]^2 + bparticle[3]^2)
@@ -87,7 +87,7 @@ Nonrelativistic definition:
 function get_gc(xu, param::TPTuple)
 	q2m, _, B_field = param
 	t = xu[end]
-	v = @view xu[4:6]
+	v = xu[SA[4:6...]]
 	B = B_field(xu, t)
 	B² = B[1]^2 + B[2]^2 + B[3]^2
 	# vector of Larmor radius
@@ -99,7 +99,7 @@ end
 function get_gc(xu, param::FullTPTuple)
 	q, m, _, B_field = param
 	t = xu[end]
-	v = @view xu[4:6]
+	v = xu[SA[4:6...]]
 	B = B_field(xu, t)
 	B² = B[1]^2 + B[2]^2 + B[3]^2
 	# vector of Larmor radius
@@ -145,24 +145,24 @@ get_gc(x, y, z, vx, vy, vz, bx, by, bz, q, m) =
 	get_gc(x, y, z, vx, vy, vz, bx, by, bz, q/m)
 
 """
-	 get_gc(param::Union{TPTuple, FullTPTuple})
+	 get_gc_func(param::Union{TPTuple, FullTPTuple})
 
 Return the function for plotting the orbit of guiding center.
 
 # Example
 ```julia
 param = prepare(E, B; species=Proton)
-gc = get_gc(param)
 # The definitions of stateinit, tspan, E and B are ignored.
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern7(); dt=2e-11)
 
 f = Figure(fontsize=18)
 ax = Axis3(f[1, 1], aspect = :data)
-gc_plot(x,y,z,vx,vy,vz) = (gc([x,y,z,vx,vy,vz])...,)
+gc = param |> get_gc_func
+gc_plot(x,y,z,vx,vy,vz) = (gc(SA[x,y,z,vx,vy,vz])...,)
 lines!(ax, sol, idxs=(gc_plot, 1, 2, 3, 4, 5, 6))
 ```
 """
-function get_gc(param::Union{TPTuple, FullTPTuple})
+function get_gc_func(param::Union{TPTuple, FullTPTuple})
 	gc(xu) = get_gc(xu, param)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,7 +207,7 @@ end
 		sol = solve(prob, Tsit5(); save_idxs = [1])
 
 		@test get_gc([stateinit..., 0.0], param)[1] == 1.59275e7
-		@test get_gc(param) isa Function
+		@test get_gc_func(param) isa Function
 		@test sol[1, 300] ≈ 1.2563192407332942e7 rtol=1e-6
 
 		# static array version (results not identical with above: maybe some bugs?)
@@ -521,8 +521,8 @@ end
 		sol_gc = solve(prob_gc, Vern9())
 
 		# analytical drifts
-		gc = param |> get_gc
-		gc_x0 = gc(stateinit)
+		gc = param |> get_gc_func
+		gc_x0 = gc(stateinit) |> Vector # needs mutation
 		prob_gc_analytic = ODEProblem(trace_gc_drifts!, gc_x0, tspan, (param..., sol))
 		sol_gc_analytic = solve(prob_gc_analytic, Vern9(); save_idxs = [1, 2, 3])
 		@test sol_gc[1, end] ≈ 0.9896155284173717


### PR DESCRIPTION
* Rename previous `get_gc` that returns a function to `get_gc_func`
* Replace views with SA indexing (inspired by the suggestions of @Beforerr)

---

It is also good to see that solving GC equations is not actually slower than brute-force tracing. Unnecessary allocation is removed from `trace_gc_1st!`.