### PR TITLE
feat: introduce ZeroField for better performance

### DIFF
--- a/src/equations.jl
+++ b/src/equations.jl
@@ -12,11 +12,11 @@ function trace!(dy, y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
 
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
 	dy[1:3] = v
-	dy[4:6] = q2m * (v × B + E)
+	dy[4:6] = SVector{3}(q2m * (v × B + E))
 
 	return
 end
@@ -25,12 +25,12 @@ function trace!(dy, y, p::FullTPTuple, t)
 	q, m, Efunc, Bfunc, Ffunc = p
 
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
-	F = SVector{3}(Ffunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
+	F = Ffunc(y, t)
 
 	dy[1:3] = v
-	dy[4:6] = (q * (v × B + E) + F) / m
+	dy[4:6] = SVector{3}((q * (v × B + E) + F) / m)
 
 	return
 end
@@ -46,10 +46,10 @@ ODE equations for charged particle moving in static EM field and external force 
 function trace(y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
-	dv = q2m * (v × B + E)
+	dv = SVector{3}(q2m * (v × B + E))
 
 	vcat(v, dv)
 end
@@ -58,11 +58,11 @@ function trace(y, p::FullTPTuple, t)
 	q, m, Efunc, Bfunc, Ffunc = p
 
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
-	F = SVector{3}(Ffunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
+	F = Ffunc(y, t)
 
-	dv = (q * (v × B + E) + F) / m
+	dv = SVector{3}((q * (v × B + E) + F) / m)
 
 	vcat(v, dv)
 end
@@ -74,8 +74,8 @@ ODE equations for relativistic charged particle (x, γv) moving in static EM fie
 """
 function trace_relativistic!(dy, y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
 	γv = y[SA[4:6...]]
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
@@ -88,7 +88,7 @@ function trace_relativistic!(dy, y, p::TPTuple, t)
 	v = vmag * v̂
 
 	dy[1:3] = v
-	dy[4:6] = q2m * (v × B + E)
+	dy[4:6] = SVector{3}(q2m * (v × B + E))
 
 	return
 end
@@ -100,8 +100,8 @@ ODE equations for relativistic charged particle (x, γv) moving in static EM fie
 """
 function trace_relativistic(y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
 	γv = y[SA[4:6...]]
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
@@ -112,7 +112,7 @@ function trace_relativistic(y, p::TPTuple, t)
 	end
 	vmag = √(γ²v² / (1 + γ²v²/c^2))
 	v = vmag * v̂
-	dv = q2m * (v × B + E)
+	dv = SVector{3}(q2m * (v × B + E))
 
 	vcat(v, dv)
 end
@@ -128,11 +128,11 @@ function trace_normalized!(dy, y, p::TPNormalizedTuple, t)
 	_, Efunc, Bfunc = p
 
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
 	dy[1:3] = v
-	dy[4:6] = v × B + E
+	dy[4:6] = SVector{3}(v × B + E)
 
 	return
 end
@@ -144,8 +144,8 @@ Normalized ODE equations for relativistic charged particle (x, γv) moving in st
 """
 function trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
 	_, Efunc, Bfunc = p
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 	γv = y[SA[4:6...]]
 
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
@@ -158,7 +158,7 @@ function trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
 	v = vmag * v̂
 
 	dy[1:3] = v
-	dy[4:6] = v × B + E
+	dy[4:6] = SVector{3}(v × B + E)
 
 	return
 end
@@ -170,19 +170,19 @@ Normalized ODE equations for relativistic charged particle (x, γv) moving in st
 """
 function trace_relativistic_normalized(y, p::TPNormalizedTuple, t)
 	_, Efunc, Bfunc = p
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 	γv = y[SA[4:6...]]
 
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(y))
 		v̂ = normalize(γv)
 	else # no velocity
-		v̂ = SVector{3, eltype(y)}(0, 0, 0)
+		v̂ = SVector{3,eltype(y)}(0, 0, 0)
 	end
 	vmag = √(γ²v² / (1 + γ²v²))
 	v = vmag * v̂
-	dv = v × B + E
+	dv = SVector{3}(v × B + E)
 
 	vcat(v, dv)
 end
@@ -197,8 +197,8 @@ function trace_gc_drifts!(dx, x, p, t)
 	q2m, Efunc, Bfunc, sol = p
 	xu = sol(t)
 	v = xu[SA[4:6...]]
-	E = SVector{3}(Efunc(x))
-	B = SVector{3}(Bfunc(x))
+	E = Efunc(x)
+	B = Bfunc(x)
 
 	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
 	∇B = ForwardDiff.gradient(Bmag, x)
@@ -223,8 +223,8 @@ function trace_gc!(dy, y, p::GCTuple, t)
 	q, m, μ, Efunc, Bfunc = p
 	q2m = q / m
 	X = y[SA[1:3...]]
-	E = SVector{3}(Efunc(X, t))
-	B = SVector{3}(Bfunc(X, t))
+	E = Efunc(X, t)
+	B = Bfunc(X, t)
 	b̂ = normalize(B) # unit B field at X
 
 	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))


### PR DESCRIPTION
The idea is that is we know something is zero we can make calculation simpler. A example is given below

```
using TestParticle, StaticArrays
using TestParticle: ZeroField

uniform_B(x) = SA[0.0, 0.0, 1e-8]
uniform_E(x) = SA[0.0, 0.0, 0.0]

zero_E = ZeroField()

# Initial condition
stateinit = let x0 = [1.0, 0, 0], v0 = [0.0, 1.0, 0.1]
   [x0..., v0...]
end
# Time span

param = prepare(uniform_E, uniform_B, species=Proton)

@code_typed trace(stateinit, param, 0.0)

param2 = prepare(zero_E, uniform_B, species=Proton)

@code_typed trace(stateinit, param2, 0.0)
```

Original `@code_typed` info
```
julia> @code_typed trace(stateinit, param, 0.0)
CodeInfo(
1 ── %1  = Base.getfield(p, 1)::Float64
│    %2  = StaticArrays.getfield($(QuoteNode([4, 5, 6])), :data)::Tuple{Int64, Int64, Int64}
│    %3  = $(Expr(:boundscheck, true))::Bool
│    %4  = Base.getfield(%2, 1, %3)::Int64
│    %5  = $(Expr(:boundscheck, true))::Bool
└───       goto #5 if not %5
2 ── %7  = Base.sub_int(%4, 1)::Int64
│    %8  = Base.bitcast(Base.UInt, %7)::UInt64
│    %9  = Base.getfield(y, :size)::Tuple{Int64}
│    %10 = $(Expr(:boundscheck, true))::Bool
│    %11 = Base.getfield(%9, 1, %10)::Int64
│    %12 = Base.bitcast(Base.UInt, %11)::UInt64
│    %13 = Base.ult_int(%8, %12)::Bool
└───       goto #4 if not %13
3 ──       goto #5
4 ── %16 = Core.tuple(%4)::Tuple{Int64}
│          invoke Base.throw_boundserror(y::Vector{Float64}, %16::Tuple{Int64})::Union{}
└───       unreachable
5 ┄─ %19 = Base.getfield(y, :ref)::MemoryRef{Float64}
│    %20 = Base.memoryrefnew(%19, %4, false)::MemoryRef{Float64}
│    %21 = Base.memoryrefget(%20, :not_atomic, false)::Float64
└───       goto #6
6 ── %23 = StaticArrays.getfield($(QuoteNode([4, 5, 6])), :data)::Tuple{Int64, Int64, Int64}
│    %24 = $(Expr(:boundscheck, true))::Bool
│    %25 = Base.getfield(%23, 2, %24)::Int64
│    %26 = $(Expr(:boundscheck, true))::Bool
└───       goto #10 if not %26
7 ── %28 = Base.sub_int(%25, 1)::Int64
│    %29 = Base.bitcast(Base.UInt, %28)::UInt64
│    %30 = Base.getfield(y, :size)::Tuple{Int64}
│    %31 = $(Expr(:boundscheck, true))::Bool
│    %32 = Base.getfield(%30, 1, %31)::Int64
│    %33 = Base.bitcast(Base.UInt, %32)::UInt64
│    %34 = Base.ult_int(%29, %33)::Bool
└───       goto #9 if not %34
8 ──       goto #10
9 ── %37 = Core.tuple(%25)::Tuple{Int64}
│          invoke Base.throw_boundserror(y::Vector{Float64}, %37::Tuple{Int64})::Union{}
└───       unreachable
10 ┄ %40 = Base.getfield(y, :ref)::MemoryRef{Float64}
│    %41 = Base.memoryrefnew(%40, %25, false)::MemoryRef{Float64}
│    %42 = Base.memoryrefget(%41, :not_atomic, false)::Float64
└───       goto #11
11 ─ %44 = StaticArrays.getfield($(QuoteNode([4, 5, 6])), :data)::Tuple{Int64, Int64, Int64}
│    %45 = $(Expr(:boundscheck, true))::Bool
│    %46 = Base.getfield(%44, 3, %45)::Int64
│    %47 = $(Expr(:boundscheck, true))::Bool
└───       goto #15 if not %47
12 ─ %49 = Base.sub_int(%46, 1)::Int64
│    %50 = Base.bitcast(Base.UInt, %49)::UInt64
│    %51 = Base.getfield(y, :size)::Tuple{Int64}
│    %52 = $(Expr(:boundscheck, true))::Bool
│    %53 = Base.getfield(%51, 1, %52)::Int64
│    %54 = Base.bitcast(Base.UInt, %53)::UInt64
│    %55 = Base.ult_int(%50, %54)::Bool
└───       goto #14 if not %55
13 ─       goto #15
14 ─ %58 = Core.tuple(%46)::Tuple{Int64}
│          invoke Base.throw_boundserror(y::Vector{Float64}, %58::Tuple{Int64})::Union{}
└───       unreachable
15 ┄ %61 = Base.getfield(y, :ref)::MemoryRef{Float64}
│    %62 = Base.memoryrefnew(%61, %46, false)::MemoryRef{Float64}
│    %63 = Base.memoryrefget(%62, :not_atomic, false)::Float64
└───       goto #16
16 ─       goto #17
17 ─       goto #18
18 ─       goto #19
19 ─ %68 = Base.mul_float(%42, 1.0e-8)::Float64
│    %69 = Base.mul_float(%63, 0.0)::Float64
│    %70 = Base.sub_float(%68, %69)::Float64
│    %71 = Base.mul_float(%63, 0.0)::Float64
│    %72 = Base.mul_float(%21, 1.0e-8)::Float64
│    %73 = Base.sub_float(%71, %72)::Float64
│    %74 = Base.mul_float(%21, 0.0)::Float64
│    %75 = Base.mul_float(%42, 0.0)::Float64
│    %76 = Base.sub_float(%74, %75)::Float64
│    %77 = $(Expr(:boundscheck, false))::Bool
│    %78 = Base.getfield((0.0, 0.0, 0.0), 1, %77)::Float64
│    %79 = Base.add_float(%70, %78)::Float64
│    %80 = $(Expr(:boundscheck, false))::Bool
│    %81 = Base.getfield((0.0, 0.0, 0.0), 2, %80)::Float64
│    %82 = Base.add_float(%73, %81)::Float64
│    %83 = $(Expr(:boundscheck, false))::Bool
│    %84 = Base.getfield((0.0, 0.0, 0.0), 3, %83)::Float64
│    %85 = Base.add_float(%76, %84)::Float64
│    %86 = Base.mul_float(%1, %79)::Float64
│    %87 = Base.mul_float(%1, %82)::Float64
│    %88 = Base.mul_float(%1, %85)::Float64
│    %89 = StaticArrays.tuple(%21, %42, %63, %86, %87, %88)::NTuple{6, Float64}
│    %90 = %new(SVector{6, Float64}, %89)::SVector{6, Float64}
└───       return %90
) => SVector{6, Float64}
```

With this commit it becomes (the only change part is `19 ─ %68 = Base.mul_float(%42, 1.0e-8)::Float64`, easier to see using some diff tool.

```
CodeInfo(
1 ── %1  = Base.getfield(p, 1)::Float64
│    %2  = StaticArrays.getfield($(QuoteNode([4, 5, 6])), :data)::Tuple{Int64, Int64, Int64}
│    %3  = $(Expr(:boundscheck, true))::Bool
│    %4  = Base.getfield(%2, 1, %3)::Int64
│    %5  = $(Expr(:boundscheck, true))::Bool
└───       goto #5 if not %5
2 ── %7  = Base.sub_int(%4, 1)::Int64
│    %8  = Base.bitcast(Base.UInt, %7)::UInt64
│    %9  = Base.getfield(y, :size)::Tuple{Int64}
│    %10 = $(Expr(:boundscheck, true))::Bool
│    %11 = Base.getfield(%9, 1, %10)::Int64
│    %12 = Base.bitcast(Base.UInt, %11)::UInt64
│    %13 = Base.ult_int(%8, %12)::Bool
└───       goto #4 if not %13
3 ──       goto #5
4 ── %16 = Core.tuple(%4)::Tuple{Int64}
│          invoke Base.throw_boundserror(y::Vector{Float64}, %16::Tuple{Int64})::Union{}
└───       unreachable
5 ┄─ %19 = Base.getfield(y, :ref)::MemoryRef{Float64}
│    %20 = Base.memoryrefnew(%19, %4, false)::MemoryRef{Float64}
│    %21 = Base.memoryrefget(%20, :not_atomic, false)::Float64
└───       goto #6
6 ── %23 = StaticArrays.getfield($(QuoteNode([4, 5, 6])), :data)::Tuple{Int64, Int64, Int64}
│    %24 = $(Expr(:boundscheck, true))::Bool
│    %25 = Base.getfield(%23, 2, %24)::Int64
│    %26 = $(Expr(:boundscheck, true))::Bool
└───       goto #10 if not %26
7 ── %28 = Base.sub_int(%25, 1)::Int64
│    %29 = Base.bitcast(Base.UInt, %28)::UInt64
│    %30 = Base.getfield(y, :size)::Tuple{Int64}
│    %31 = $(Expr(:boundscheck, true))::Bool
│    %32 = Base.getfield(%30, 1, %31)::Int64
│    %33 = Base.bitcast(Base.UInt, %32)::UInt64
│    %34 = Base.ult_int(%29, %33)::Bool
└───       goto #9 if not %34
8 ──       goto #10
9 ── %37 = Core.tuple(%25)::Tuple{Int64}
│          invoke Base.throw_boundserror(y::Vector{Float64}, %37::Tuple{Int64})::Union{}
└───       unreachable
10 ┄ %40 = Base.getfield(y, :ref)::MemoryRef{Float64}
│    %41 = Base.memoryrefnew(%40, %25, false)::MemoryRef{Float64}
│    %42 = Base.memoryrefget(%41, :not_atomic, false)::Float64
└───       goto #11
11 ─ %44 = StaticArrays.getfield($(QuoteNode([4, 5, 6])), :data)::Tuple{Int64, Int64, Int64}
│    %45 = $(Expr(:boundscheck, true))::Bool
│    %46 = Base.getfield(%44, 3, %45)::Int64
│    %47 = $(Expr(:boundscheck, true))::Bool
└───       goto #15 if not %47
12 ─ %49 = Base.sub_int(%46, 1)::Int64
│    %50 = Base.bitcast(Base.UInt, %49)::UInt64
│    %51 = Base.getfield(y, :size)::Tuple{Int64}
│    %52 = $(Expr(:boundscheck, true))::Bool
│    %53 = Base.getfield(%51, 1, %52)::Int64
│    %54 = Base.bitcast(Base.UInt, %53)::UInt64
│    %55 = Base.ult_int(%50, %54)::Bool
└───       goto #14 if not %55
13 ─       goto #15
14 ─ %58 = Core.tuple(%46)::Tuple{Int64}
│          invoke Base.throw_boundserror(y::Vector{Float64}, %58::Tuple{Int64})::Union{}
└───       unreachable
15 ┄ %61 = Base.getfield(y, :ref)::MemoryRef{Float64}
│    %62 = Base.memoryrefnew(%61, %46, false)::MemoryRef{Float64}
│    %63 = Base.memoryrefget(%62, :not_atomic, false)::Float64
└───       goto #16
16 ─       goto #17
17 ─       goto #18
18 ─       goto #19
19 ─ %68 = Base.mul_float(%42, 1.0e-8)::Float64
│    %69 = Base.mul_float(%63, 0.0)::Float64
│    %70 = Base.sub_float(%68, %69)::Float64
│    %71 = Base.mul_float(%63, 0.0)::Float64
│    %72 = Base.mul_float(%21, 1.0e-8)::Float64
│    %73 = Base.sub_float(%71, %72)::Float64
│    %74 = Base.mul_float(%21, 0.0)::Float64
│    %75 = Base.mul_float(%42, 0.0)::Float64
│    %76 = Base.sub_float(%74, %75)::Float64
│    %77 = Base.mul_float(%1, %70)::Float64
│    %78 = Base.mul_float(%1, %73)::Float64
│    %79 = Base.mul_float(%1, %76)::Float64
│    %80 = StaticArrays.tuple(%21, %42, %63, %77, %78, %79)::NTuple{6, Float64}
│    %81 = %new(SVector{6, Float64}, %80)::SVector{6, Float64}
└───       return %81
) => SVector{6, Float64}
```