### PR TITLE
refactor: unify `prepare` and `trace` interface

### DIFF
--- a/docs/examples/advanced/demo_fermi_foreshock.jl
+++ b/docs/examples/advanced/demo_fermi_foreshock.jl
@@ -32,6 +32,7 @@ import DisplayAs #hide
 using TestParticle, OrdinaryDiffEqVerner, StaticArrays
 import TestParticle as TP
 using TestParticle: mₑ, Rₑ, qₑ
+using TestParticle: get_EField, get_BField
 using Random
 using FHist
 using CairoMakie, Printf
@@ -122,9 +123,11 @@ function plot_multiple(sol)
    energy = map(x -> get_kinetic_energy(x[4:6]...), sol.u) .* mₑ ./ abs(qₑ)
    ## Obtain the EM fields along the particle trajectory
    ## [mV/m]
-   E = [sol.prob.p[2](sol[:,istep], sol.t[istep]).*1e3 for istep in eachindex(sol)]
+   Efield = get_EField(sol)
+   Bfield = get_BField(sol)
+   E = [Efield(sol[:,istep], sol.t[istep]).*1e3 for istep in eachindex(sol)]
    ## [nT]
-   B = [sol.prob.p[3](sol[:,istep], sol.t[istep]).*1e9 for istep in eachindex(sol)]
+   B = [Bfield(sol[:,istep], sol.t[istep]).*1e9 for istep in eachindex(sol)]
 
    Ex = [e[1] for e in E]
    Ey = [e[2] for e in E]

--- a/docs/examples/advanced/demo_output_func.jl
+++ b/docs/examples/advanced/demo_output_func.jl
@@ -17,6 +17,7 @@
 
 import DisplayAs #hide
 using TestParticle, OrdinaryDiffEqVerner, StaticArrays
+using TestParticle: get_BField
 using Statistics
 using LinearAlgebra: normalize, ×, ⋅
 using Random
@@ -28,7 +29,7 @@ Random.seed!(seed)
 
 "Set initial state for EnsembleProblem."
 function prob_func(prob, i, repeat)
-   B0 = prob.p[3](prob.u0)
+   B0 = get_BField(prob)(prob.u0)
    B0 = normalize(B0)
 
    Bperp1 = SA[0.0, -B0[3], B0[2]] |> normalize
@@ -102,7 +103,7 @@ prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
 
 "Set customized outputs for the ensemble problem."
 function output_func(sol, i)
-   getB = sol.prob.p[3]
+   getB = get_BField(sol)
    b = getB.(sol.u)
 
    μ = [@views b[i] ⋅ sol[4:6, i] / sqrt(sum(x -> x^2, b[i])) for i in eachindex(sol)]   

--- a/docs/examples/advanced/demo_savingcallback.jl
+++ b/docs/examples/advanced/demo_savingcallback.jl
@@ -22,6 +22,7 @@
 
 using TestParticle, OrdinaryDiffEqVerner, StaticArrays
 using TestParticle: qᵢ, mᵢ
+using TestParticle: get_BField
 using Statistics
 using LinearAlgebra: normalize, ×, ⋅
 using DiffEqCallbacks
@@ -75,7 +76,7 @@ stateinit = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 prob = ODEProblem(trace_normalized!, stateinit, tspan, param)
 
 prob.u0[4:6] = let
-   B0 = prob.p[3](prob.u0)
+   B0 = get_BField(prob)(prob.u0)
    B0 = normalize(B0)
 
    Bperp1 = SA[0.0, -B0[3], B0[2]] |> normalize
@@ -93,7 +94,7 @@ end
 saved_values = SavedValues(Float64, Tuple{SVector{3, Float64}, Float64})
 
 function save_B_mu(u, t, integrator)
-   b = integrator.p[3](u)
+   b = get_BField(integrator.p)(u)
    μ = @views b ⋅ u[4:6] / √(b[1]^2 + b[2]^2 + b[3]^2)
 
    b, μ

--- a/docs/examples/basics/demo_Buniform_Ezero.jl
+++ b/docs/examples/basics/demo_Buniform_Ezero.jl
@@ -12,11 +12,12 @@
 
 import DisplayAs #hide
 using TestParticle, OrdinaryDiffEqVerner, StaticArrays
+using TestParticle: ZeroField
 using CairoMakie
 CairoMakie.activate!(type = "png") #hide
 
 uniform_B(x) = SA[0.0, 0.0, 1e-8]
-uniform_E(x) = SA[0.0, 0.0, 0.0]
+zero_E = ZeroField()
 
 ## Initial condition
 stateinit = let x0 = [1.0, 0, 0], v0 = [0.0, 1.0, 0.1]
@@ -25,7 +26,7 @@ end
 ## Time span
 tspan = (0, 18)
 
-param = prepare(uniform_E, uniform_B, species=Proton)
+param = prepare(zero_E, uniform_B, species=Proton)
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 

--- a/docs/examples/basics/demo_ExB_drift.jl
+++ b/docs/examples/basics/demo_ExB_drift.jl
@@ -15,6 +15,7 @@
 import DisplayAs #hide
 using TestParticle, OrdinaryDiffEqVerner, StaticArrays
 using LinearAlgebra: ⋅, ×, normalize
+using TestParticle: get_EField, get_BField
 using CairoMakie
 CairoMakie.activate!(type = "png") #hide
 
@@ -24,13 +25,15 @@ uniform_E(x) = SA[1e-9, 0, 0]
 
 ## Trace the orbit of the guiding center
 function trace_gc_ExB!(dx, x, p, t)
-   _, E, B, sol = p
+   sol = p[end]
+   Bfunc = get_BField(p)
+   Efunc = get_EField(p)
    xu = sol(t)
-   Bv = B(x)
+   Bv = Bfunc(x)
    b = normalize(Bv)
    v_par = @views (xu[4:6] ⋅ b) .* b
    B2 = sum(Bv.^2)
-   dx[1:3] = (E(x) × Bv) / B2 + v_par
+   dx[1:3] = (Efunc(x) × Bv) / B2 + v_par
 end
 ## Initial condition
 stateinit = let x0 = [1.0, 0.0, 0.0], v0 = [0.0, 1.0, 0.1]

--- a/docs/examples/basics/demo_FLR.jl
+++ b/docs/examples/basics/demo_FLR.jl
@@ -29,7 +29,7 @@ end
 
 ## trace the orbit of the guiding center
 function trace_gc!(dx, x, p, t)
-    q2m, E, B, sol = p
+    q2m, _, E, B, _, sol = p
     xu = sol(t)
     xp = @view xu[1:3]
     Bv = B(xp)

--- a/docs/examples/basics/demo_boris.jl
+++ b/docs/examples/basics/demo_boris.jl
@@ -13,6 +13,7 @@
 
 import DisplayAs #hide
 using TestParticle, OrdinaryDiffEqTsit5, StaticArrays
+using TestParticle: ZeroField, get_BField
 import TestParticle as TP
 using CairoMakie
 CairoMakie.activate!(type = "png") #hide
@@ -38,16 +39,16 @@ end
 
 const Bmag = 0.01
 uniform_B(x) = SA[0.0, 0.0, Bmag]
-uniform_E(x) = SA[0.0, 0.0, 0.0]
+zero_E = ZeroField()
 
 x0 = [0.0, 0.0, 0.0]
 v0 = [0.0, 1e5, 0.0]
 stateinit = [x0..., v0...]
 
-param = prepare(uniform_E, uniform_B, species=Electron)
+param = prepare(zero_E, uniform_B, species=Electron)
 
 ## Reference parameters
-const tperiod = 2π / (abs(param[1]) * sqrt(sum(x -> x^2, param[3]([0.0,0.0,0.0], 0.0))))
+const tperiod = 2π / (abs(param[1]) * sqrt(sum(x -> x^2, get_BField(param)([0.0,0.0,0.0], 0.0))))
 const rL = sqrt(v0[1]^2 + v0[2]^2 + v0[3]^2) / (abs(param[1]) * Bmag)
 const invrL = 1 / rL;
 

--- a/docs/examples/basics/demo_energy_conservation.jl
+++ b/docs/examples/basics/demo_energy_conservation.jl
@@ -11,6 +11,7 @@
 
 import DisplayAs #hide
 using TestParticle, OrdinaryDiffEq, StaticArrays
+using TestParticle: ZeroField
 import TestParticle as TP
 using LinearAlgebra: ×
 using CairoMakie
@@ -20,13 +21,13 @@ const B₀ = 1e-8 # [T]
 const E₀ = 3e-2 # [V/m]
 
 "f2"
-function location!(dx, v, x, p::TP.TPTuple, t)
+function location!(dx, v, x, p, t)
    dx .= v
 end
 
 "f1"
-function lorentz!(dv, v, x, p::TP.TPTuple, t)
-   q2m, E, B = p
+function lorentz!(dv, v, x, p, t)
+   q2m, _, E, B = p
    dv .= q2m*(E(x, t) + v × (B(x, t)))
 end
 
@@ -40,13 +41,8 @@ function uniform_E(x)
    return SA[E₀, 0.0, 0.0]
 end
 
-function zero_B(x)
-   return SA[0.0, 0.0, 0.0]
-end
-
-function zero_E(x)
-   return SA[0.0, 0.0, 0.0]
-end
+zero_B = ZeroField()
+zero_E = ZeroField()
 
 "Check energy conservation."
 E(dx, dy, dz) = 1 // 2 * (dx^2 + dy^2 + dz^2)

--- a/docs/examples/basics/demo_gradient_B.jl
+++ b/docs/examples/basics/demo_gradient_B.jl
@@ -31,7 +31,7 @@ abs_B(x) = norm(grad_B(x))
 
 ## Trace the orbit of the guiding center using analytical drifts
 function trace_gc!(dx, x, p, t)
-    q2m, E, B, sol = p
+    q2m, _, E, B, _, sol = p
     xu = sol(t)
     gradient_B = gradient(abs_B, x)
     Bv = B(x)

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -1,22 +1,22 @@
 # Tracing equations.
 
-function get_dv(u, v, p, t)
-    q2m, m, Efunc, Bfunc, Ffunc = p
-    E = Efunc(u, t)
-    B = Bfunc(u, t)
-    F = Ffunc(u, t)
+function get_dv(x, v, p, t)
+	q2m, m, Efunc, Bfunc, Ffunc = p
+	E = Efunc(x, t)
+	B = Bfunc(x, t)
+	F = Ffunc(x, t)
 
-    SVector{3}(q2m * (v × B + E) + F / m)
+	SVector{3}(q2m * (v × B + E) + F / m)
 end
 
 function get_relativistic_v(γv; c=c)
-    γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
-    if γ²v² > eps(eltype(γv))
-        v̂ = normalize(γv)
-    else # no velocity
-        v̂ = SVector{3,eltype(γv)}(0, 0, 0)
-    end
-    √(γ²v² / (1 + γ²v² / c^2)) * v̂
+	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
+	if γ²v² > eps(eltype(γv))
+		v̂ = normalize(γv)
+	else # no velocity
+		v̂ = SVector{3,eltype(γv)}(0, 0, 0)
+	end
+	√(γ²v² / (1 + γ²v² / c^2)) * v̂
 end
 
 
@@ -26,10 +26,10 @@ end
 ODE equations for charged particle moving in static EM field and external force field with in-place form.
 """
 function trace!(dy, y, p, t)
-    v = y[SA[4:6...]]
-    dy[1:3] = v
-    dy[4:6] = get_dv(y, v, p, t)
-    return
+	v = y[SA[4:6...]]
+	dy[1:3] = v
+	dy[4:6] = get_dv(y, v, p, t)
+	return
 end
 
 """
@@ -38,9 +38,9 @@ end
 ODE equations for charged particle moving in static EM field and external force field with out-of-place form.
 """
 function trace(y, p, t)
-    v = y[SA[4:6...]]
-    dv = get_dv(y, v, p, t)
-    vcat(v, dv)
+	v = y[SA[4:6...]]
+	dv = get_dv(y, v, p, t)
+	vcat(v, dv)
 end
 
 """
@@ -49,12 +49,12 @@ end
 ODE equations for relativistic charged particle (x, γv) moving in static EM field with in-place form.
 """
 function trace_relativistic!(dy, y, p, t)
-    γv = y[SA[4:6...]]
-    v = get_relativistic_v(γv)
-    dy[1:3] = v
-    dy[4:6] = get_dv(y, v, p, t)
+	γv = y[SA[4:6...]]
+	v = get_relativistic_v(γv)
+	dy[1:3] = v
+	dy[4:6] = get_dv(y, v, p, t)
 
-    return
+	return
 end
 
 """
@@ -63,11 +63,11 @@ end
 ODE equations for relativistic charged particle (x, γv) moving in static EM field with out-of-place form.
 """
 function trace_relativistic(y, p, t)
-    γv = y[SA[4:6...]]
-    v = get_relativistic_v(γv)
-    dv = get_dv(y, v, p, t)
+	γv = y[SA[4:6...]]
+	v = get_relativistic_v(γv)
+	dv = get_dv(y, v, p, t)
 
-    vcat(v, dv)
+	vcat(v, dv)
 end
 
 """
@@ -78,16 +78,14 @@ If the field is in 2D X-Y plane, periodic boundary should be applied for the fie
 the extrapolation function provided by Interpolations.jl.
 """
 function trace_normalized!(dy, y, p, t)
-    _, m, Efunc, Bfunc = p
+	v = y[SA[4:6...]]
+	E = get_EField(p)(y, t)
+	B = get_BField(p)(y, t)
 
-    v = y[SA[4:6...]]
-    E = Efunc(y, t)
-    B = Bfunc(y, t)
+	dy[1:3] = v
+	dy[4:6] = SVector{3}(v × B + E)
 
-    dy[1:3] = v
-    dy[4:6] = SVector{3}(v × B + E)
-
-    return
+	return
 end
 
 """
@@ -96,16 +94,15 @@ end
 Normalized ODE equations for relativistic charged particle (x, γv) moving in static EM field with in-place form.
 """
 function trace_relativistic_normalized!(dy, y, p, t)
-    _, m, Efunc, Bfunc = p
-    E = Efunc(y, t)
-    B = Bfunc(y, t)
-    γv = y[SA[4:6...]]
+	E = get_EField(p)(y, t)
+	B = get_BField(p)(y, t)
+	γv = y[SA[4:6...]]
 
-    v = get_relativistic_v(γv; c=1)
-    dy[1:3] = v
-    dy[4:6] = SVector{3}(v × B + E)
+	v = get_relativistic_v(γv; c=1)
+	dy[1:3] = v
+	dy[4:6] = SVector{3}(v × B + E)
 
-    return
+	return
 end
 
 """
@@ -114,15 +111,14 @@ end
 Normalized ODE equations for relativistic charged particle (x, γv) moving in static EM field with out-of-place form.
 """
 function trace_relativistic_normalized(y, p, t)
-    _, m, Efunc, Bfunc = p
-    E = Efunc(y, t)
-    B = Bfunc(y, t)
-    γv = y[SA[4:6...]]
+	E = get_EField(p)(y, t)
+	B = get_BField(p)(y, t)
+	γv = y[SA[4:6...]]
 
-    v = get_relativistic_v(γv; c=1)
-    dv = SVector{3}(v × B + E)
+	v = get_relativistic_v(γv; c=1)
+	dv = SVector{3}(v × B + E)
 
-    vcat(v, dv)
+	vcat(v, dv)
 end
 
 """
@@ -132,23 +128,23 @@ Equations for tracing the guiding center using analytical drifts, including the 
 Parallel velocity is also added. This expression requires the full particle trajectory `p.sol`.
 """
 function trace_gc_drifts!(dx, x, p, t)
-    q2m, _, Efunc, Bfunc, _, sol = p
-    xu = sol(t)
-    v = xu[SA[4:6...]]
-    E = Efunc(x)
-    B = Bfunc(x)
+	q2m, _, Efunc, Bfunc, _, sol = p
+	xu = sol(t)
+	v = xu[SA[4:6...]]
+	E = Efunc(x)
+	B = Bfunc(x)
 
-    Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
-    ∇B = ForwardDiff.gradient(Bmag, x)
-    b = normalize(B)
-    v_par = (v ⋅ b) .* b
-    v_perp = v - v_par
-    Ω = q2m * norm(B)
-    κ = ForwardDiff.jacobian(Bfunc, x) * B  # B⋅∇B
-    ## v⟂^2*(B×∇|B|)/(2*Ω*B^2) + v∥^2*(B×(B⋅∇B))/(Ω*B^3) + (E×B)/B^2 + v∥
-    dx[1:3] =
-        norm(v_perp)^2 * (B × ∇B) / (2 * Ω * norm(B)^2) +
-        norm(v_par)^2 * (B × κ) / Ω / norm(B)^3 + (E × B) / (B ⋅ B) + v_par
+	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
+	∇B = ForwardDiff.gradient(Bmag, x)
+	b = normalize(B)
+	v_par = (v ⋅ b) .* b
+	v_perp = v - v_par
+	Ω = q2m * norm(B)
+	κ = ForwardDiff.jacobian(Bfunc, x) * B  # B⋅∇B
+	## v⟂^2*(B×∇|B|)/(2*Ω*B^2) + v∥^2*(B×(B⋅∇B))/(Ω*B^3) + (E×B)/B^2 + v∥
+	dx[1:3] =
+		norm(v_perp)^2 * (B × ∇B) / (2 * Ω * norm(B)^2) +
+		norm(v_par)^2 * (B × κ) / Ω / norm(B)^3 + (E × B) / (B ⋅ B) + v_par
 end
 
 """
@@ -158,66 +154,66 @@ Guiding center equations for nonrelativistic charged particle moving in static E
 Variable `y = (x, y, z, u)`, where `u` is the velocity along the magnetic field at (x,y,z).
 """
 function trace_gc!(dy, y, p::GCTuple, t)
-    q, m, μ, Efunc, Bfunc = p
-    q2m = q / m
-    X = y[SA[1:3...]]
-    E = Efunc(X, t)
-    B = Bfunc(X, t)
-    b̂ = normalize(B) # unit B field at X
+	q, m, μ, Efunc, Bfunc = p
+	q2m = q / m
+	X = y[SA[1:3...]]
+	E = Efunc(X, t)
+	B = Bfunc(X, t)
+	b̂ = normalize(B) # unit B field at X
 
-    Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
-    ∇B = SVector{3}(ForwardDiff.gradient(Bmag, X))
+	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
+	∇B = SVector{3}(ForwardDiff.gradient(Bmag, X))
 
-    function E2B(x)
-        E² = Efunc(x) ⋅ Efunc(x)
-        B² = Bfunc(x) ⋅ Bfunc(x)
-        vE² = E² / B²
-    end
+	function E2B(x)
+		E² = Efunc(x) ⋅ Efunc(x)
+		B² = Bfunc(x) ⋅ Bfunc(x)
+		vE² = E² / B²
+	end
 
-    ∇vE² = SVector{3}(ForwardDiff.gradient(E2B, X))
+	∇vE² = SVector{3}(ForwardDiff.gradient(E2B, X))
 
-    bfunc(x) = normalize(Bfunc(x, t))
-    ∇b̂ = ForwardDiff.jacobian(bfunc, X)
-    # ∇ × b̂
-    curlb = SVector{3}(∇b̂[3, 2] - ∇b̂[2, 3], ∇b̂[1, 3] - ∇b̂[3, 1], ∇b̂[2, 1] - ∇b̂[1, 2])
-    # effective EM fields
-    Eᵉ = @. E - (μ * ∇B - 0.5 * m * ∇vE²) / q
-    Bᵉ = @. B + y[4] / q2m * curlb
-    Bparᵉ = b̂ ⋅ Bᵉ # effective B field parallel to B
+	bfunc(x) = normalize(Bfunc(x, t))
+	∇b̂ = ForwardDiff.jacobian(bfunc, X)
+	# ∇ × b̂
+	curlb = SVector{3}(∇b̂[3, 2] - ∇b̂[2, 3], ∇b̂[1, 3] - ∇b̂[3, 1], ∇b̂[2, 1] - ∇b̂[1, 2])
+	# effective EM fields
+	Eᵉ = @. E - (μ * ∇B - 0.5 * m * ∇vE²) / q
+	Bᵉ = @. B + y[4] / q2m * curlb
+	Bparᵉ = b̂ ⋅ Bᵉ # effective B field parallel to B
 
-    dy[1] = (y[4] * Bᵉ[1] + Eᵉ[2] * b̂[3] - Eᵉ[3] * b̂[2]) / Bparᵉ
-    dy[2] = (y[4] * Bᵉ[2] + Eᵉ[3] * b̂[1] - Eᵉ[1] * b̂[3]) / Bparᵉ
-    dy[3] = (y[4] * Bᵉ[3] + Eᵉ[1] * b̂[2] - Eᵉ[2] * b̂[1]) / Bparᵉ
-    dy[4] = q2m / Bparᵉ * Bᵉ ⋅ Eᵉ
+	dy[1] = (y[4] * Bᵉ[1] + Eᵉ[2] * b̂[3] - Eᵉ[3] * b̂[2]) / Bparᵉ
+	dy[2] = (y[4] * Bᵉ[2] + Eᵉ[3] * b̂[1] - Eᵉ[1] * b̂[3]) / Bparᵉ
+	dy[3] = (y[4] * Bᵉ[3] + Eᵉ[1] * b̂[2] - Eᵉ[2] * b̂[1]) / Bparᵉ
+	dy[4] = q2m / Bparᵉ * Bᵉ ⋅ Eᵉ
 
-    return
+	return
 end
 
 "1st order approximation of guiding center equations."
 function trace_gc_1st!(dy, y, p::GCTuple, t)
-    q, m, μ, Efunc, Bfunc = p
-    q2m = q / m
-    X = y[SA[1:3...]]
-    E = Efunc(X, t)
-    B = Bfunc(X, t)
-    b̂ = normalize(B) # unit B field at X
-    u = y[4]
+	q, m, μ, Efunc, Bfunc = p
+	q2m = q / m
+	X = y[SA[1:3...]]
+	E = Efunc(X, t)
+	B = Bfunc(X, t)
+	b̂ = normalize(B) # unit B field at X
+	u = y[4]
 
-    Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
-    ∇B = SVector{3}(ForwardDiff.gradient(Bmag, X))
-    Ω = q * Bmag(X) / m
+	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
+	∇B = SVector{3}(ForwardDiff.gradient(Bmag, X))
+	Ω = q * Bmag(X) / m
 
-    bfunc(x) = normalize(Bfunc(x, t))
-    ∇b̂ = ForwardDiff.jacobian(bfunc, X)
-    # effective EM fields
-    Eᵉ = @. E - (μ * ∇B) / q
-    κ = ∇b̂ * b̂  # curvature
-    vX = u * b̂ + b̂ × (κ * u^2 - q2m * Eᵉ) / Ω
+	bfunc(x) = normalize(Bfunc(x, t))
+	∇b̂ = ForwardDiff.jacobian(bfunc, X)
+	# effective EM fields
+	Eᵉ = @. E - (μ * ∇B) / q
+	κ = ∇b̂ * b̂  # curvature
+	vX = u * b̂ + b̂ × (κ * u^2 - q2m * Eᵉ) / Ω
 
-    dy[1] = vX[1]
-    dy[2] = vX[2]
-    dy[3] = vX[3]
-    dy[4] = q2m * (b̂ + u * (b̂ × κ) / Ω) ⋅ Eᵉ
+	dy[1] = vX[1]
+	dy[2] = vX[2]
+	dy[3] = vX[3]
+	dy[4] = q2m * (b̂ + u * (b̂ × κ) / Ω) ⋅ Eᵉ
 
-    return
+	return
 end

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -86,8 +86,8 @@ function trace_normalized!(dy, y, p, t)
 	E = get_EField(p)(y, t)
 	B = get_BField(p)(y, t)
 
-	dy[1:3] = v
-	dy[4:6] = SVector{3}(v × B + E)
+	@inbounds dy[1:3] = v
+	@inbounds dy[4:6] = SVector{3}(v × B + E)
 
 	return
 end
@@ -103,8 +103,8 @@ function trace_relativistic_normalized!(dy, y, p, t)
 	γv = get_v(y)
 
 	v = get_relativistic_v(γv; c=1)
-	dy[1:3] = v
-	dy[4:6] = SVector{3}(v × B + E)
+	@inbounds dy[1:3] = v
+	@inbounds dy[4:6] = SVector{3}(v × B + E)
 
 	return
 end
@@ -146,9 +146,11 @@ function trace_gc_drifts!(dx, x, p, t)
 	Ω = q2m * norm(B)
 	κ = ForwardDiff.jacobian(Bfunc, x) * B  # B⋅∇B
 	## v⟂^2*(B×∇|B|)/(2*Ω*B^2) + v∥^2*(B×(B⋅∇B))/(Ω*B^3) + (E×B)/B^2 + v∥
-	dx[1:3] =
+	@inbounds dx[1:3] =
 		norm(v_perp)^2 * (B × ∇B) / (2 * Ω * norm(B)^2) +
 		norm(v_par)^2 * (B × κ) / Ω / norm(B)^3 + (E × B) / (B ⋅ B) + v_par
+
+   return
 end
 
 """

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -1,190 +1,128 @@
 # Tracing equations.
 
-"""
-	 trace!(dy, y, p::TPTuple, t)
-	 trace!(dy, y, p::FullTPTuple, t)
+function get_dv(u, v, p, t)
+    q2m, m, Efunc, Bfunc, Ffunc = p
+    E = Efunc(u, t)
+    B = Bfunc(u, t)
+    F = Ffunc(u, t)
 
-ODE equations for charged particle moving in static EM field with in-place form.
+    SVector{3}(q2m * (v × B + E) + F / m)
+end
+
+function get_relativistic_v(γv; c=c)
+    γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
+    if γ²v² > eps(eltype(γv))
+        v̂ = normalize(γv)
+    else # no velocity
+        v̂ = SVector{3,eltype(γv)}(0, 0, 0)
+    end
+    √(γ²v² / (1 + γ²v² / c^2)) * v̂
+end
+
+
+"""
+	trace!(dy, y, p, t)
 
 ODE equations for charged particle moving in static EM field and external force field with in-place form.
 """
-function trace!(dy, y, p::TPTuple, t)
-	q2m, Efunc, Bfunc = p
-
-	v = y[SA[4:6...]]
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
-
-	dy[1:3] = v
-	dy[4:6] = SVector{3}(q2m * (v × B + E))
-
-	return
-end
-
-function trace!(dy, y, p::FullTPTuple, t)
-	q, m, Efunc, Bfunc, Ffunc = p
-
-	v = y[SA[4:6...]]
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
-	F = Ffunc(y, t)
-
-	dy[1:3] = v
-	dy[4:6] = SVector{3}((q * (v × B + E) + F) / m)
-
-	return
+function trace!(dy, y, p, t)
+    v = y[SA[4:6...]]
+    dy[1:3] = v
+    dy[4:6] = get_dv(y, v, p, t)
+    return
 end
 
 """
-	 trace(y, p::TPTuple, t) -> SVector{6, Float64}
-	 trace(y, p::FullTPTuple, t) -> SVector{6, Float64}
-
-ODE equations for charged particle moving in static EM field with out-of-place form.
+	trace(y, p, t) -> SVector{6, Float64}
 
 ODE equations for charged particle moving in static EM field and external force field with out-of-place form.
 """
-function trace(y, p::TPTuple, t)
-	q2m, Efunc, Bfunc = p
-	v = y[SA[4:6...]]
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
-
-	dv = SVector{3}(q2m * (v × B + E))
-
-	vcat(v, dv)
-end
-
-function trace(y, p::FullTPTuple, t)
-	q, m, Efunc, Bfunc, Ffunc = p
-
-	v = y[SA[4:6...]]
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
-	F = Ffunc(y, t)
-
-	dv = SVector{3}((q * (v × B + E) + F) / m)
-
-	vcat(v, dv)
+function trace(y, p, t)
+    v = y[SA[4:6...]]
+    dv = get_dv(y, v, p, t)
+    vcat(v, dv)
 end
 
 """
-	 trace_relativistic!(dy, y, p::TPTuple, t)
+	 trace_relativistic!(dy, y, p, t)
 
 ODE equations for relativistic charged particle (x, γv) moving in static EM field with in-place form.
 """
-function trace_relativistic!(dy, y, p::TPTuple, t)
-	q2m, Efunc, Bfunc = p
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
+function trace_relativistic!(dy, y, p, t)
+    γv = y[SA[4:6...]]
+    v = get_relativistic_v(γv)
+    dy[1:3] = v
+    dy[4:6] = get_dv(y, v, p, t)
 
-	γv = y[SA[4:6...]]
-	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
-	if γ²v² > eps(eltype(dy))
-		v̂ = normalize(γv)
-	else # no velocity
-		v̂ = SVector{3, eltype(dy)}(0, 0, 0)
-	end
-	vmag = √(γ²v² / (1 + γ²v²/c^2))
-	v = vmag * v̂
-
-	dy[1:3] = v
-	dy[4:6] = SVector{3}(q2m * (v × B + E))
-
-	return
+    return
 end
 
 """
-	 trace_relativistic(y, p::TPTuple, t) -> SVector{6}
+	 trace_relativistic(y, p, t) -> SVector{6}
 
 ODE equations for relativistic charged particle (x, γv) moving in static EM field with out-of-place form.
 """
-function trace_relativistic(y, p::TPTuple, t)
-	q2m, Efunc, Bfunc = p
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
+function trace_relativistic(y, p, t)
+    γv = y[SA[4:6...]]
+    v = get_relativistic_v(γv)
+    dv = get_dv(y, v, p, t)
 
-	γv = y[SA[4:6...]]
-	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
-	if γ²v² > eps(eltype(y))
-		v̂ = normalize(γv)
-	else # no velocity
-		v̂ = SVector{3, eltype(y)}(0, 0, 0)
-	end
-	vmag = √(γ²v² / (1 + γ²v²/c^2))
-	v = vmag * v̂
-	dv = SVector{3}(q2m * (v × B + E))
-
-	vcat(v, dv)
+    vcat(v, dv)
 end
 
 """
-	 trace_normalized!(dy, y, p::TPNormalizedTuple, t)
+	 trace_normalized!(dy, y, p, t)
 
 Normalized ODE equations for charged particle moving in static EM field with in-place form.
 If the field is in 2D X-Y plane, periodic boundary should be applied for the field in z via
 the extrapolation function provided by Interpolations.jl.
 """
-function trace_normalized!(dy, y, p::TPNormalizedTuple, t)
-	_, Efunc, Bfunc = p
+function trace_normalized!(dy, y, p, t)
+    _, m, Efunc, Bfunc = p
 
-	v = y[SA[4:6...]]
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
+    v = y[SA[4:6...]]
+    E = Efunc(y, t)
+    B = Bfunc(y, t)
 
-	dy[1:3] = v
-	dy[4:6] = SVector{3}(v × B + E)
+    dy[1:3] = v
+    dy[4:6] = SVector{3}(v × B + E)
 
-	return
+    return
 end
 
 """
-	 trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
+	 trace_relativistic_normalized!(dy, y, p, t)
 
 Normalized ODE equations for relativistic charged particle (x, γv) moving in static EM field with in-place form.
 """
-function trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
-	_, Efunc, Bfunc = p
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
-	γv = y[SA[4:6...]]
+function trace_relativistic_normalized!(dy, y, p, t)
+    _, m, Efunc, Bfunc = p
+    E = Efunc(y, t)
+    B = Bfunc(y, t)
+    γv = y[SA[4:6...]]
 
-	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
-	if γ²v² > eps(eltype(dy))
-		v̂ = normalize(γv)
-	else # no velocity
-		v̂ = SVector{3, eltype(dy)}(0, 0, 0)
-	end
-	vmag = √(γ²v² / (1 + γ²v²))
-	v = vmag * v̂
+    v = get_relativistic_v(γv; c=1)
+    dy[1:3] = v
+    dy[4:6] = SVector{3}(v × B + E)
 
-	dy[1:3] = v
-	dy[4:6] = SVector{3}(v × B + E)
-
-	return
+    return
 end
 
 """
-	 trace_relativistic_normalized(y, p::TPNormalizedTuple, t)
+	 trace_relativistic_normalized(y, p, t)
 
 Normalized ODE equations for relativistic charged particle (x, γv) moving in static EM field with out-of-place form.
 """
-function trace_relativistic_normalized(y, p::TPNormalizedTuple, t)
-	_, Efunc, Bfunc = p
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
-	γv = y[SA[4:6...]]
+function trace_relativistic_normalized(y, p, t)
+    _, m, Efunc, Bfunc = p
+    E = Efunc(y, t)
+    B = Bfunc(y, t)
+    γv = y[SA[4:6...]]
 
-	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
-	if γ²v² > eps(eltype(y))
-		v̂ = normalize(γv)
-	else # no velocity
-		v̂ = SVector{3,eltype(y)}(0, 0, 0)
-	end
-	vmag = √(γ²v² / (1 + γ²v²))
-	v = vmag * v̂
-	dv = SVector{3}(v × B + E)
+    v = get_relativistic_v(γv; c=1)
+    dv = SVector{3}(v × B + E)
 
-	vcat(v, dv)
+    vcat(v, dv)
 end
 
 """
@@ -194,23 +132,23 @@ Equations for tracing the guiding center using analytical drifts, including the 
 Parallel velocity is also added. This expression requires the full particle trajectory `p.sol`.
 """
 function trace_gc_drifts!(dx, x, p, t)
-	q2m, Efunc, Bfunc, sol = p
-	xu = sol(t)
-	v = xu[SA[4:6...]]
-	E = Efunc(x)
-	B = Bfunc(x)
+    q2m, _, Efunc, Bfunc, _, sol = p
+    xu = sol(t)
+    v = xu[SA[4:6...]]
+    E = Efunc(x)
+    B = Bfunc(x)
 
-	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
-	∇B = ForwardDiff.gradient(Bmag, x)
-	b = normalize(B)
-	v_par = (v ⋅ b) .* b
-	v_perp = v - v_par
-	Ω = q2m*norm(B)
-	κ = ForwardDiff.jacobian(Bfunc, x) * B  # B⋅∇B
-	## v⟂^2*(B×∇|B|)/(2*Ω*B^2) + v∥^2*(B×(B⋅∇B))/(Ω*B^3) + (E×B)/B^2 + v∥
-	dx[1:3] =
-		norm(v_perp)^2*(B × ∇B)/(2*Ω*norm(B)^2) +
-		norm(v_par)^2*(B × κ)/Ω/norm(B)^3 + (E × B)/(B ⋅ B) + v_par
+    Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
+    ∇B = ForwardDiff.gradient(Bmag, x)
+    b = normalize(B)
+    v_par = (v ⋅ b) .* b
+    v_perp = v - v_par
+    Ω = q2m * norm(B)
+    κ = ForwardDiff.jacobian(Bfunc, x) * B  # B⋅∇B
+    ## v⟂^2*(B×∇|B|)/(2*Ω*B^2) + v∥^2*(B×(B⋅∇B))/(Ω*B^3) + (E×B)/B^2 + v∥
+    dx[1:3] =
+        norm(v_perp)^2 * (B × ∇B) / (2 * Ω * norm(B)^2) +
+        norm(v_par)^2 * (B × κ) / Ω / norm(B)^3 + (E × B) / (B ⋅ B) + v_par
 end
 
 """
@@ -220,66 +158,66 @@ Guiding center equations for nonrelativistic charged particle moving in static E
 Variable `y = (x, y, z, u)`, where `u` is the velocity along the magnetic field at (x,y,z).
 """
 function trace_gc!(dy, y, p::GCTuple, t)
-	q, m, μ, Efunc, Bfunc = p
-	q2m = q / m
-	X = y[SA[1:3...]]
-	E = Efunc(X, t)
-	B = Bfunc(X, t)
-	b̂ = normalize(B) # unit B field at X
+    q, m, μ, Efunc, Bfunc = p
+    q2m = q / m
+    X = y[SA[1:3...]]
+    E = Efunc(X, t)
+    B = Bfunc(X, t)
+    b̂ = normalize(B) # unit B field at X
 
-	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
-	∇B = SVector{3}(ForwardDiff.gradient(Bmag, X))
+    Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
+    ∇B = SVector{3}(ForwardDiff.gradient(Bmag, X))
 
-	function E2B(x)
-		E² = Efunc(x) ⋅ Efunc(x)
-		B² = Bfunc(x) ⋅ Bfunc(x)
-		vE² = E² / B²
-	end
+    function E2B(x)
+        E² = Efunc(x) ⋅ Efunc(x)
+        B² = Bfunc(x) ⋅ Bfunc(x)
+        vE² = E² / B²
+    end
 
-	∇vE² = SVector{3}(ForwardDiff.gradient(E2B, X))
+    ∇vE² = SVector{3}(ForwardDiff.gradient(E2B, X))
 
-	bfunc(x) = normalize(Bfunc(x, t))
-	∇b̂ = ForwardDiff.jacobian(bfunc, X)
-	# ∇ × b̂
-	curlb = SVector{3}(∇b̂[3, 2] - ∇b̂[2, 3], ∇b̂[1, 3] - ∇b̂[3, 1], ∇b̂[2, 1] - ∇b̂[1, 2])
-	# effective EM fields
-	Eᵉ = @. E - (μ*∇B - 0.5*m*∇vE²) / q
-	Bᵉ = @. B + y[4] / q2m * curlb
-	Bparᵉ = b̂ ⋅ Bᵉ # effective B field parallel to B
+    bfunc(x) = normalize(Bfunc(x, t))
+    ∇b̂ = ForwardDiff.jacobian(bfunc, X)
+    # ∇ × b̂
+    curlb = SVector{3}(∇b̂[3, 2] - ∇b̂[2, 3], ∇b̂[1, 3] - ∇b̂[3, 1], ∇b̂[2, 1] - ∇b̂[1, 2])
+    # effective EM fields
+    Eᵉ = @. E - (μ * ∇B - 0.5 * m * ∇vE²) / q
+    Bᵉ = @. B + y[4] / q2m * curlb
+    Bparᵉ = b̂ ⋅ Bᵉ # effective B field parallel to B
 
-	dy[1] = (y[4] * Bᵉ[1] + Eᵉ[2]*b̂[3] - Eᵉ[3]*b̂[2]) / Bparᵉ
-	dy[2] = (y[4] * Bᵉ[2] + Eᵉ[3]*b̂[1] - Eᵉ[1]*b̂[3]) / Bparᵉ
-	dy[3] = (y[4] * Bᵉ[3] + Eᵉ[1]*b̂[2] - Eᵉ[2]*b̂[1]) / Bparᵉ
-	dy[4] = q2m / Bparᵉ * Bᵉ ⋅ Eᵉ
+    dy[1] = (y[4] * Bᵉ[1] + Eᵉ[2] * b̂[3] - Eᵉ[3] * b̂[2]) / Bparᵉ
+    dy[2] = (y[4] * Bᵉ[2] + Eᵉ[3] * b̂[1] - Eᵉ[1] * b̂[3]) / Bparᵉ
+    dy[3] = (y[4] * Bᵉ[3] + Eᵉ[1] * b̂[2] - Eᵉ[2] * b̂[1]) / Bparᵉ
+    dy[4] = q2m / Bparᵉ * Bᵉ ⋅ Eᵉ
 
-	return
+    return
 end
 
 "1st order approximation of guiding center equations."
 function trace_gc_1st!(dy, y, p::GCTuple, t)
-	q, m, μ, Efunc, Bfunc = p
-	q2m = q / m
-	X = y[SA[1:3...]]
-	E = Efunc(X, t)
-	B = Bfunc(X, t)
-	b̂ = normalize(B) # unit B field at X
-	u = y[4]
+    q, m, μ, Efunc, Bfunc = p
+    q2m = q / m
+    X = y[SA[1:3...]]
+    E = Efunc(X, t)
+    B = Bfunc(X, t)
+    b̂ = normalize(B) # unit B field at X
+    u = y[4]
 
-	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
-	∇B = SVector{3}(ForwardDiff.gradient(Bmag, X))
-	Ω = q * Bmag(X) / m
+    Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
+    ∇B = SVector{3}(ForwardDiff.gradient(Bmag, X))
+    Ω = q * Bmag(X) / m
 
-	bfunc(x) = normalize(Bfunc(x, t))
-	∇b̂ = ForwardDiff.jacobian(bfunc, X)
-	# effective EM fields
-	Eᵉ = @. E - (μ*∇B) / q
-	κ = ∇b̂ * b̂  # curvature
-	vX = u * b̂ + b̂ × (κ*u^2 - q2m*Eᵉ) / Ω
+    bfunc(x) = normalize(Bfunc(x, t))
+    ∇b̂ = ForwardDiff.jacobian(bfunc, X)
+    # effective EM fields
+    Eᵉ = @. E - (μ * ∇B) / q
+    κ = ∇b̂ * b̂  # curvature
+    vX = u * b̂ + b̂ × (κ * u^2 - q2m * Eᵉ) / Ω
 
-	dy[1] = vX[1]
-	dy[2] = vX[2]
-	dy[3] = vX[3]
-	dy[4] = q2m * (b̂ + u*(b̂ × κ)/Ω) ⋅ Eᵉ
+    dy[1] = vX[1]
+    dy[2] = vX[2]
+    dy[3] = vX[3]
+    dy[4] = q2m * (b̂ + u * (b̂ × κ) / Ω) ⋅ Eᵉ
 
-	return
+    return
 end

--- a/src/gc.jl
+++ b/src/gc.jl
@@ -73,7 +73,7 @@ function prepare_gc(xv, E, B; species::Species = Proton, q::AbstractFloat = 1.0,
 end
 
 """
-	 get_gc(xu, param::Union{TPTuple, FullTPTuple})
+	 get_gc(xu, param)
 	 get_gc(x, y, z, vx, vy, vz, bx, by, bz, q2m)
 
 Calculate the coordinates of the guiding center according to the phase space coordinates of a particle.
@@ -84,26 +84,15 @@ Nonrelativistic definition:
 \\mathbf{X}=\\mathbf{x}-m\\frac{\\mathbf{b}\\times\\mathbf{v}}{qB}
 ```
 """
-function get_gc(xu, param::TPTuple)
-	q2m, _, B_field = param
+function get_gc(xu, param)
+	q2m = get_q2m(param)
+	B_field = get_BField(param)
 	t = xu[end]
 	v = xu[SA[4:6...]]
 	B = B_field(xu, t)
 	B² = B[1]^2 + B[2]^2 + B[3]^2
 	# vector of Larmor radius
 	ρ = B × v ./ (q2m*B²)
-
-	X = @views xu[1:3] - ρ
-end
-
-function get_gc(xu, param::FullTPTuple)
-	q, m, _, B_field = param
-	t = xu[end]
-	v = xu[SA[4:6...]]
-	B = B_field(xu, t)
-	B² = B[1]^2 + B[2]^2 + B[3]^2
-	# vector of Larmor radius
-	ρ = B × v ./ (q*B²/m)
 
 	X = @views xu[1:3] - ρ
 end

--- a/src/prepare.jl
+++ b/src/prepare.jl
@@ -58,12 +58,21 @@ TPNormalizedTuple = Tuple{AbstractFloat, AbstractField, AbstractField}
 "The type of parameter tuple for guiding center problem."
 GCTuple = Tuple{Float64, Float64, Float64, AbstractField, AbstractField}
 
+get_q2m(param) = param[1]
+get_BField(param::TPTuple) = param[3]
+get_BField(param) = param[4]
+get_EField(param::TPTuple) = param[2]
+get_EField(param) = param[3]
 
 """
-	 prepare(grid::CartesianGrid, E, B; kwargs...) -> (q2m, E, B)
+	prepare(args...; kwargs...) -> (q2m, m, E, B, F)
+	prepare(E, B, F = ZeroField(); kwargs...)
 
-Return a tuple consists of particle charge-mass ratio for a prescribed `species` and
-interpolated EM field functions.
+Return a tuple consists of particle charge-mass ratio for a prescribed `species` of charge `q` and mass `m`,
+	mass `m` for a prescribed `species`, analytic/interpolated EM field functions, and external force `F`.
+
+Prescribed `species` are `Electron` and `Proton`; 
+	other species can be manually specified with `species=Ion/User`, `q` and `m`.
 
 # Keywords
 - `order::Int=1`: order of interpolation in [1,2,3].
@@ -72,30 +81,20 @@ interpolated EM field functions.
 - `q::AbstractFloat=1.0`: particle charge. Only works when `Species=User`.
 - `m::AbstractFloat=1.0`: particle mass. Only works when `Species=User`.
 
-	 prepare(grid::CartesianGrid, E, B, F; species=Proton, q=1.0, m=1.0) -> (q, m, E, B, F)
+	 prepare(grid::CartesianGrid, E, B; kwargs...)
+	 prepare(grid::CartesianGrid, E, B, F; species=Proton, q=1.0, m=1.0)
 
 Return a tuple consists of particle charge, mass for a prescribed `species` of charge `q`
 and mass `m`, interpolated EM field functions, and external force `F`.
 
-	 prepare(x::AbstractRange, y::AbstractRange, z::AbstractRange, E, B; kwargs...) -> (q2m, E, B)
-	 prepare(x, y, E, B; kwargs...) -> (q2m, E, B)
+	 prepare(x::AbstractRange, y::AbstractRange, z::AbstractRange, E, B; kwargs...)
+	 prepare(x, y, E, B; kwargs...)
 
-	 prepare(x::AbstractRange, E, B; kwargs...) -> (q2m, E, B)
+	 prepare(x::AbstractRange, E, B; kwargs...)
 
 1D grid. An additional keyword `dir` is used for specifying the spatial direction, 1 -> x, 2 -> y, 3 -> z.
 
 Direct range input for uniform grid in 2/3D is also accepted.
-
-	 prepare(E, B; kwargs...) -> (q2m, E, B)
-
-Return a tuple consists of particle charge-mass ratio for a prescribed `species` of charge
-`q` and mass `m` and analytic EM field functions. Prescribed `species` are `Electron` and
-`Proton`; other species can be manually specified with `species=Ion/User`, `q` and `m`.
-
-	 prepare(E, B, F; kwargs...) -> (q, m, E, B, F)
-
-Return a tuple consists of particle charge, mass for a prescribed `species` of charge `q`
-and mass `m`, analytic EM field functions, and external force `F`.
 """
 function prepare(grid::CartesianGrid, E::TE, B::TB; species::Species = Proton,
 	q::AbstractFloat = 1.0, m::AbstractFloat = 1.0, order::Int = 1, bc::Int = 1,
@@ -113,7 +112,7 @@ function prepare(grid::CartesianGrid, E::TE, B::TB; species::Species = Proton,
 		B = TB <: AbstractArray ? getinterp(B, gridx, gridy, order, bc) : B
 	end
 
-	q/m, Field(E), Field(B)
+	q/m, m, Field(E), Field(B), ZeroField()
 end
 
 function prepare(grid::CartesianGrid, E::TE, B::TB, F::TF; species::Species = Proton,
@@ -128,7 +127,7 @@ function prepare(grid::CartesianGrid, E::TE, B::TB, F::TF; species::Species = Pr
 	B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz, order, bc) : B
 	F = TF <: AbstractArray ? getinterp(F, gridx, gridy, gridz, order, bc) : F
 
-	q, m, Field(E), Field(B), Field(F)
+	q/m, m, Field(E), Field(B), Field(F)
 end
 
 function prepare(x::T, y::T, E::TE, B::TB; species::Species = Proton,
@@ -140,7 +139,7 @@ function prepare(x::T, y::T, E::TE, B::TB; species::Species = Proton,
 	E = TE <: AbstractArray ? getinterp(E, x, y, order, bc) : E
 	B = TB <: AbstractArray ? getinterp(B, x, y, order, bc) : B
 
-	q/m, Field(E), Field(B)
+	q/m, m, Field(E), Field(B), ZeroField()
 end
 
 function prepare(x::T, E::TE, B::TB; species::Species = Proton, q::AbstractFloat = 1.0,
@@ -152,7 +151,7 @@ function prepare(x::T, E::TE, B::TB; species::Species = Proton, q::AbstractFloat
 	E = TE <: AbstractArray ? getinterp(E, x, order, bc; dir) : E
 	B = TB <: AbstractArray ? getinterp(B, x, order, bc; dir) : B
 
-	q/m, Field(E), Field(B)
+	q/m, m, Field(E), Field(B), ZeroField()
 end
 
 function prepare(x::T, y::T, z::T, E::TE, B::TB;
@@ -165,30 +164,18 @@ function prepare(x::T, y::T, z::T, E::TE, B::TB;
 	E = TE <: AbstractArray ? getinterp(E, x, y, z, order, bc) : E
 	B = TB <: AbstractArray ? getinterp(B, x, y, z, order, bc) : B
 
-	q/m, Field(E), Field(B)
+	q/m, m, Field(E), Field(B), ZeroField()
 end
 
-function prepare(
-	E,
-	B;
-	species::Species = Proton,
-	q::AbstractFloat = 1.0,
-	m::AbstractFloat = 1.0,
-)
-	q, m = getchargemass(species, q, m)
-
-	q/m, Field(E), Field(B)
-end
-
-function prepare(E, B, F; species::Species = Proton, q::AbstractFloat = 1.0,
+function prepare(E, B, F = ZeroField(); species::Species = Proton, q::AbstractFloat = 1.0,
 	m::AbstractFloat = 1.0)
 	q, m = getchargemass(species, q, m)
 
-	q, m, Field(E), Field(B), Field(F)
+	q/m, m, Field(E), Field(B), Field(F)
 end
 
 
-import Base: (+), (*), (/), setindex!
+import Base: (+), (*), (/), setindex!, getindex
 import LinearAlgebra: ×
 import StaticArrays: StaticArray
 
@@ -211,7 +198,9 @@ struct ZeroVector end
 
 # Make ZeroVector work with array assignment
 Base.setindex!(A::AbstractArray, ::ZeroVector, I...) = fill!(view(A, I...), 0)
+Base.getindex(::ZeroVector, I...) = 0
 
 # Field interface
 Field(x::ZeroField) = x
 (::ZeroField)(y, t) = ZeroVector()
+(::ZeroField)(_) = ZeroVector()

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -13,6 +13,10 @@ struct TraceProblem{uType, tType, isinplace, P, F <: AbstractODEFunction, PF} <:
 	prob_func::PF
 end
 
+
+get_EField(p::AbstractODEProblem) = get_EField(p.p)
+get_BField(p::AbstractODEProblem) = get_BField(p.p)
+
 struct TraceSolution{T, N, uType, uType2, DType, tType, rateType, P, A, IType, S, AC} <:
 		 AbstractODESolution{T, N, uType}
 	"positions and velocities"
@@ -40,6 +44,9 @@ function TraceSolution{T, N}(u, u_analytic, errors, t, k, prob, alg, interp, den
 		typeof(alg_choice)}(u, u_analytic, errors, t, k, prob, alg, interp,
 		dense, tslocation, stats, alg_choice, retcode)
 end
+
+get_BField(sol::AbstractODESolution) = get_BField(sol.prob)
+get_EField(sol::AbstractODESolution) = get_EField(sol.prob)
 
 Base.length(ts::TraceSolution) = length(ts.t)
 
@@ -111,7 +118,9 @@ Reference: [DTIC](https://apps.dtic.mil/sti/citations/ADA023511)
 """
 function update_velocity!(xv, paramBoris, param, dt, t)
 	(; v⁻, v′, v⁺, t_rotate, s_rotate, v⁻_cross_t, v′_cross_s) = paramBoris
-	q2m, E, B = param[1], param[2](xv, t), param[3](xv, t)
+	q2m, _, Efunc, Bfunc = param
+	E = Efunc(xv, t)
+	B = Bfunc(xv, t)
 	# t vector
 	for dim in 1:3
 		t_rotate[dim] = q2m*B[dim]*0.5*dt


### PR DESCRIPTION
Julia compiler is sooooo smart that when `F` is `ZeroField()` the typed codes is exactly the same with previous `TPTuple` codes so now unification comes with no runtime cost.

Now `prepare(args...; kwargs...)` always return `(q2m, m, E, B, F)`