### PR TITLE
perf: remove bounds check in typed code (this check is redundant)

### DIFF
--- a/docs/examples/basics/demo_Buniform_Ezero.jl
+++ b/docs/examples/basics/demo_Buniform_Ezero.jl
@@ -12,11 +12,12 @@
 
 import DisplayAs #hide
 using TestParticle, OrdinaryDiffEqVerner, StaticArrays
+using TestParticle: ZeroField
 using CairoMakie
 CairoMakie.activate!(type = "png") #hide
 
 uniform_B(x) = SA[0.0, 0.0, 1e-8]
-uniform_E(x) = SA[0.0, 0.0, 0.0]
+zero_E = ZeroField()
 
 ## Initial condition
 stateinit = let x0 = [1.0, 0, 0], v0 = [0.0, 1.0, 0.1]
@@ -25,7 +26,7 @@ end
 ## Time span
 tspan = (0, 18)
 
-param = prepare(uniform_E, uniform_B, species=Proton)
+param = prepare(zero_E, uniform_B, species=Proton)
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol = solve(prob, Vern9())
 

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -1,28 +1,12 @@
 # Tracing equations.
 
 """
-	 trace!(dy, y, p::TPTuple, t)
-	 trace!(dy, y, p::FullTPTuple, t)
-
-ODE equations for charged particle moving in static EM field with in-place form.
+	trace!(dy, y, p, t)
 
 ODE equations for charged particle moving in static EM field and external force field with in-place form.
 """
-function trace!(dy, y, p::TPTuple, t)
-	q2m, Efunc, Bfunc = p
-
-	v = y[SA[4:6...]]
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
-
-	dy[1:3] = v
-	dy[4:6] = SVector{3}(q2m * (v × B + E))
-
-	return
-end
-
-function trace!(dy, y, p::FullTPTuple, t)
-	q, m, Efunc, Bfunc, Ffunc = p
+function trace!(dy, y, p, t)
+	q2m, m, Efunc, Bfunc, Ffunc = p
 
 	v = y[SA[4:6...]]
 	E = Efunc(y, t)
@@ -30,52 +14,39 @@ function trace!(dy, y, p::FullTPTuple, t)
 	F = Ffunc(y, t)
 
 	dy[1:3] = v
-	dy[4:6] = SVector{3}((q * (v × B + E) + F) / m)
+	dy[4:6] = SVector{3}(q2m * (v × B + E) + F / m)
 
 	return
 end
 
 """
-	 trace(y, p::TPTuple, t) -> SVector{6, Float64}
-	 trace(y, p::FullTPTuple, t) -> SVector{6, Float64}
-
-ODE equations for charged particle moving in static EM field with out-of-place form.
+	trace(y, p, t) -> SVector{6, Float64}
 
 ODE equations for charged particle moving in static EM field and external force field with out-of-place form.
 """
-function trace(y, p::TPTuple, t)
-	q2m, Efunc, Bfunc = p
-	v = y[SA[4:6...]]
-	E = Efunc(y, t)
-	B = Bfunc(y, t)
-
-	dv = SVector{3}(q2m * (v × B + E))
-
-	vcat(v, dv)
-end
-
-function trace(y, p::FullTPTuple, t)
-	q, m, Efunc, Bfunc, Ffunc = p
+function trace(y, p, t)
+	q2m, m, Efunc, Bfunc, Ffunc = p
 
 	v = y[SA[4:6...]]
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
 	F = Ffunc(y, t)
 
-	dv = SVector{3}((q * (v × B + E) + F) / m)
+	dv = SVector{3}(q2m * (v × B + E) + F / m)
 
 	vcat(v, dv)
 end
 
 """
-	 trace_relativistic!(dy, y, p::TPTuple, t)
+	 trace_relativistic!(dy, y, p, t)
 
 ODE equations for relativistic charged particle (x, γv) moving in static EM field with in-place form.
 """
-function trace_relativistic!(dy, y, p::TPTuple, t)
-	q2m, Efunc, Bfunc = p
+function trace_relativistic!(dy, y, p, t)
+	q2m, m, Efunc, Bfunc, Ffunc = p
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
+	F = Ffunc(y, t)
 
 	γv = y[SA[4:6...]]
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
@@ -84,24 +55,25 @@ function trace_relativistic!(dy, y, p::TPTuple, t)
 	else # no velocity
 		v̂ = SVector{3, eltype(dy)}(0, 0, 0)
 	end
-	vmag = √(γ²v² / (1 + γ²v²/c^2))
+	vmag = √(γ²v² / (1 + γ²v² / c^2))
 	v = vmag * v̂
 
 	dy[1:3] = v
-	dy[4:6] = SVector{3}(q2m * (v × B + E))
+	dy[4:6] = SVector{3}(q2m * (v × B + E) + F / m)
 
 	return
 end
 
 """
-	 trace_relativistic(y, p::TPTuple, t) -> SVector{6}
+	 trace_relativistic(y, p, t) -> SVector{6}
 
 ODE equations for relativistic charged particle (x, γv) moving in static EM field with out-of-place form.
 """
-function trace_relativistic(y, p::TPTuple, t)
-	q2m, Efunc, Bfunc = p
+function trace_relativistic(y, p, t)
+	q2m, m, Efunc, Bfunc, Ffunc = p
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
+	F = Ffunc(y, t)
 
 	γv = y[SA[4:6...]]
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
@@ -118,14 +90,14 @@ function trace_relativistic(y, p::TPTuple, t)
 end
 
 """
-	 trace_normalized!(dy, y, p::TPNormalizedTuple, t)
+	 trace_normalized!(dy, y, p, t)
 
 Normalized ODE equations for charged particle moving in static EM field with in-place form.
 If the field is in 2D X-Y plane, periodic boundary should be applied for the field in z via
 the extrapolation function provided by Interpolations.jl.
 """
-function trace_normalized!(dy, y, p::TPNormalizedTuple, t)
-	_, Efunc, Bfunc = p
+function trace_normalized!(dy, y, p, t)
+	_, m, Efunc, Bfunc = p
 
 	v = y[SA[4:6...]]
 	E = Efunc(y, t)
@@ -138,12 +110,12 @@ function trace_normalized!(dy, y, p::TPNormalizedTuple, t)
 end
 
 """
-	 trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
+	 trace_relativistic_normalized!(dy, y, p, t)
 
 Normalized ODE equations for relativistic charged particle (x, γv) moving in static EM field with in-place form.
 """
-function trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
-	_, Efunc, Bfunc = p
+function trace_relativistic_normalized!(dy, y, p, t)
+	_, m, Efunc, Bfunc = p
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
 	γv = y[SA[4:6...]]
@@ -152,7 +124,7 @@ function trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
 	if γ²v² > eps(eltype(dy))
 		v̂ = normalize(γv)
 	else # no velocity
-		v̂ = SVector{3, eltype(dy)}(0, 0, 0)
+		v̂ = SVector{3,eltype(dy)}(0, 0, 0)
 	end
 	vmag = √(γ²v² / (1 + γ²v²))
 	v = vmag * v̂
@@ -164,12 +136,12 @@ function trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
 end
 
 """
-	 trace_relativistic_normalized(y, p::TPNormalizedTuple, t)
+	 trace_relativistic_normalized(y, p, t)
 
 Normalized ODE equations for relativistic charged particle (x, γv) moving in static EM field with out-of-place form.
 """
-function trace_relativistic_normalized(y, p::TPNormalizedTuple, t)
-	_, Efunc, Bfunc = p
+function trace_relativistic_normalized(y, p, t)
+	_, m, Efunc, Bfunc = p
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
 	γv = y[SA[4:6...]]
@@ -194,7 +166,7 @@ Equations for tracing the guiding center using analytical drifts, including the 
 Parallel velocity is also added. This expression requires the full particle trajectory `p.sol`.
 """
 function trace_gc_drifts!(dx, x, p, t)
-	q2m, Efunc, Bfunc, sol = p
+	q2m, m, Efunc, Bfunc, sol = p
 	xu = sol(t)
 	v = xu[SA[4:6...]]
 	E = Efunc(x)
@@ -205,12 +177,12 @@ function trace_gc_drifts!(dx, x, p, t)
 	b = normalize(B)
 	v_par = (v ⋅ b) .* b
 	v_perp = v - v_par
-	Ω = q2m*norm(B)
+	Ω = q2m * norm(B)
 	κ = ForwardDiff.jacobian(Bfunc, x) * B  # B⋅∇B
 	## v⟂^2*(B×∇|B|)/(2*Ω*B^2) + v∥^2*(B×(B⋅∇B))/(Ω*B^3) + (E×B)/B^2 + v∥
 	dx[1:3] =
-		norm(v_perp)^2*(B × ∇B)/(2*Ω*norm(B)^2) +
-		norm(v_par)^2*(B × κ)/Ω/norm(B)^3 + (E × B)/(B ⋅ B) + v_par
+		norm(v_perp)^2 * (B × ∇B) / (2 * Ω * norm(B)^2) +
+		norm(v_par)^2 * (B × κ) / Ω / norm(B)^3 + (E × B) / (B ⋅ B) + v_par
 end
 
 """
@@ -243,13 +215,13 @@ function trace_gc!(dy, y, p::GCTuple, t)
 	# ∇ × b̂
 	curlb = SVector{3}(∇b̂[3, 2] - ∇b̂[2, 3], ∇b̂[1, 3] - ∇b̂[3, 1], ∇b̂[2, 1] - ∇b̂[1, 2])
 	# effective EM fields
-	Eᵉ = @. E - (μ*∇B - 0.5*m*∇vE²) / q
+	Eᵉ = @. E - (μ * ∇B - 0.5 * m * ∇vE²) / q
 	Bᵉ = @. B + y[4] / q2m * curlb
 	Bparᵉ = b̂ ⋅ Bᵉ # effective B field parallel to B
 
-	dy[1] = (y[4] * Bᵉ[1] + Eᵉ[2]*b̂[3] - Eᵉ[3]*b̂[2]) / Bparᵉ
-	dy[2] = (y[4] * Bᵉ[2] + Eᵉ[3]*b̂[1] - Eᵉ[1]*b̂[3]) / Bparᵉ
-	dy[3] = (y[4] * Bᵉ[3] + Eᵉ[1]*b̂[2] - Eᵉ[2]*b̂[1]) / Bparᵉ
+	dy[1] = (y[4] * Bᵉ[1] + Eᵉ[2] * b̂[3] - Eᵉ[3] * b̂[2]) / Bparᵉ
+	dy[2] = (y[4] * Bᵉ[2] + Eᵉ[3] * b̂[1] - Eᵉ[1] * b̂[3]) / Bparᵉ
+	dy[3] = (y[4] * Bᵉ[3] + Eᵉ[1] * b̂[2] - Eᵉ[2] * b̂[1]) / Bparᵉ
 	dy[4] = q2m / Bparᵉ * Bᵉ ⋅ Eᵉ
 
 	return
@@ -272,14 +244,14 @@ function trace_gc_1st!(dy, y, p::GCTuple, t)
 	bfunc(x) = normalize(Bfunc(x, t))
 	∇b̂ = ForwardDiff.jacobian(bfunc, X)
 	# effective EM fields
-	Eᵉ = @. E - (μ*∇B) / q
+	Eᵉ = @. E - (μ * ∇B) / q
 	κ = ∇b̂ * b̂  # curvature
-	vX = u * b̂ + b̂ × (κ*u^2 - q2m*Eᵉ) / Ω
+	vX = u * b̂ + b̂ × (κ * u^2 - q2m * Eᵉ) / Ω
 
 	dy[1] = vX[1]
 	dy[2] = vX[2]
 	dy[3] = vX[3]
-	dy[4] = q2m * (b̂ + u*(b̂ × κ)/Ω) ⋅ Eᵉ
+	dy[4] = q2m * (b̂ + u * (b̂ × κ) / Ω) ⋅ Eᵉ
 
 	return
 end

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -1,4 +1,6 @@
 # Tracing equations.
+get_x(u) = @inbounds SA[u[1], u[2], u[3]]
+get_v(u) = @inbounds SA[u[4], u[5], u[6]]
 
 """
 	trace!(dy, y, p, t)
@@ -8,7 +10,7 @@ ODE equations for charged particle moving in static EM field and external force 
 function trace!(dy, y, p, t)
 	q2m, m, Efunc, Bfunc, Ffunc = p
 
-	v = y[SA[4:6...]]
+	v = get_v(y)
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
 	F = Ffunc(y, t)
@@ -27,7 +29,7 @@ ODE equations for charged particle moving in static EM field and external force 
 function trace(y, p, t)
 	q2m, m, Efunc, Bfunc, Ffunc = p
 
-	v = y[SA[4:6...]]
+	v = get_v(y)
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
 	F = Ffunc(y, t)
@@ -48,7 +50,7 @@ function trace_relativistic!(dy, y, p, t)
 	B = Bfunc(y, t)
 	F = Ffunc(y, t)
 
-	γv = y[SA[4:6...]]
+	γv = get_v(y)
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(dy))
 		v̂ = normalize(γv)
@@ -75,7 +77,7 @@ function trace_relativistic(y, p, t)
 	B = Bfunc(y, t)
 	F = Ffunc(y, t)
 
-	γv = y[SA[4:6...]]
+	γv = get_v(y)
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(y))
 		v̂ = normalize(γv)
@@ -99,7 +101,7 @@ the extrapolation function provided by Interpolations.jl.
 function trace_normalized!(dy, y, p, t)
 	_, m, Efunc, Bfunc = p
 
-	v = y[SA[4:6...]]
+	v = get_v(y)
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
 
@@ -118,7 +120,7 @@ function trace_relativistic_normalized!(dy, y, p, t)
 	_, m, Efunc, Bfunc = p
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
-	γv = y[SA[4:6...]]
+	γv = get_v(y)
 
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(dy))
@@ -144,7 +146,7 @@ function trace_relativistic_normalized(y, p, t)
 	_, m, Efunc, Bfunc = p
 	E = Efunc(y, t)
 	B = Bfunc(y, t)
-	γv = y[SA[4:6...]]
+	γv = get_v(y)
 
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(y))
@@ -168,7 +170,7 @@ Parallel velocity is also added. This expression requires the full particle traj
 function trace_gc_drifts!(dx, x, p, t)
 	q2m, m, Efunc, Bfunc, sol = p
 	xu = sol(t)
-	v = xu[SA[4:6...]]
+	v = get_v(xu)
 	E = Efunc(x)
 	B = Bfunc(x)
 
@@ -194,7 +196,7 @@ Variable `y = (x, y, z, u)`, where `u` is the velocity along the magnetic field 
 function trace_gc!(dy, y, p::GCTuple, t)
 	q, m, μ, Efunc, Bfunc = p
 	q2m = q / m
-	X = y[SA[1:3...]]
+	X = get_x(y)
 	E = Efunc(X, t)
 	B = Bfunc(X, t)
 	b̂ = normalize(B) # unit B field at X
@@ -231,7 +233,7 @@ end
 function trace_gc_1st!(dy, y, p::GCTuple, t)
 	q, m, μ, Efunc, Bfunc = p
 	q2m = q / m
-	X = y[SA[1:3...]]
+	X = get_x(y)
 	E = Efunc(X, t)
 	B = Bfunc(X, t)
 	b̂ = normalize(B) # unit B field at X

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -12,11 +12,11 @@ function trace!(dy, y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
 
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
 	dy[1:3] = v
-	dy[4:6] = q2m * (v × B + E)
+	dy[4:6] = SVector{3}(q2m * (v × B + E))
 
 	return
 end
@@ -25,12 +25,12 @@ function trace!(dy, y, p::FullTPTuple, t)
 	q, m, Efunc, Bfunc, Ffunc = p
 
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
-	F = SVector{3}(Ffunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
+	F = Ffunc(y, t)
 
 	dy[1:3] = v
-	dy[4:6] = (q * (v × B + E) + F) / m
+	dy[4:6] = SVector{3}((q * (v × B + E) + F) / m)
 
 	return
 end
@@ -46,10 +46,10 @@ ODE equations for charged particle moving in static EM field and external force 
 function trace(y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
-	dv = q2m * (v × B + E)
+	dv = SVector{3}(q2m * (v × B + E))
 
 	vcat(v, dv)
 end
@@ -58,11 +58,11 @@ function trace(y, p::FullTPTuple, t)
 	q, m, Efunc, Bfunc, Ffunc = p
 
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
-	F = SVector{3}(Ffunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
+	F = Ffunc(y, t)
 
-	dv = (q * (v × B + E) + F) / m
+	dv = SVector{3}((q * (v × B + E) + F) / m)
 
 	vcat(v, dv)
 end
@@ -74,8 +74,8 @@ ODE equations for relativistic charged particle (x, γv) moving in static EM fie
 """
 function trace_relativistic!(dy, y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
 	γv = y[SA[4:6...]]
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
@@ -88,7 +88,7 @@ function trace_relativistic!(dy, y, p::TPTuple, t)
 	v = vmag * v̂
 
 	dy[1:3] = v
-	dy[4:6] = q2m * (v × B + E)
+	dy[4:6] = SVector{3}(q2m * (v × B + E))
 
 	return
 end
@@ -100,8 +100,8 @@ ODE equations for relativistic charged particle (x, γv) moving in static EM fie
 """
 function trace_relativistic(y, p::TPTuple, t)
 	q2m, Efunc, Bfunc = p
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
 	γv = y[SA[4:6...]]
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
@@ -112,7 +112,7 @@ function trace_relativistic(y, p::TPTuple, t)
 	end
 	vmag = √(γ²v² / (1 + γ²v²/c^2))
 	v = vmag * v̂
-	dv = q2m * (v × B + E)
+	dv = SVector{3}(q2m * (v × B + E))
 
 	vcat(v, dv)
 end
@@ -128,11 +128,11 @@ function trace_normalized!(dy, y, p::TPNormalizedTuple, t)
 	_, Efunc, Bfunc = p
 
 	v = y[SA[4:6...]]
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 
 	dy[1:3] = v
-	dy[4:6] = v × B + E
+	dy[4:6] = SVector{3}(v × B + E)
 
 	return
 end
@@ -144,8 +144,8 @@ Normalized ODE equations for relativistic charged particle (x, γv) moving in st
 """
 function trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
 	_, Efunc, Bfunc = p
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 	γv = y[SA[4:6...]]
 
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
@@ -158,7 +158,7 @@ function trace_relativistic_normalized!(dy, y, p::TPNormalizedTuple, t)
 	v = vmag * v̂
 
 	dy[1:3] = v
-	dy[4:6] = v × B + E
+	dy[4:6] = SVector{3}(v × B + E)
 
 	return
 end
@@ -170,19 +170,19 @@ Normalized ODE equations for relativistic charged particle (x, γv) moving in st
 """
 function trace_relativistic_normalized(y, p::TPNormalizedTuple, t)
 	_, Efunc, Bfunc = p
-	E = SVector{3}(Efunc(y, t))
-	B = SVector{3}(Bfunc(y, t))
+	E = Efunc(y, t)
+	B = Bfunc(y, t)
 	γv = y[SA[4:6...]]
 
 	γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
 	if γ²v² > eps(eltype(y))
 		v̂ = normalize(γv)
 	else # no velocity
-		v̂ = SVector{3, eltype(y)}(0, 0, 0)
+		v̂ = SVector{3,eltype(y)}(0, 0, 0)
 	end
 	vmag = √(γ²v² / (1 + γ²v²))
 	v = vmag * v̂
-	dv = v × B + E
+	dv = SVector{3}(v × B + E)
 
 	vcat(v, dv)
 end
@@ -197,8 +197,8 @@ function trace_gc_drifts!(dx, x, p, t)
 	q2m, Efunc, Bfunc, sol = p
 	xu = sol(t)
 	v = xu[SA[4:6...]]
-	E = SVector{3}(Efunc(x))
-	B = SVector{3}(Bfunc(x))
+	E = Efunc(x)
+	B = Bfunc(x)
 
 	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))
 	∇B = ForwardDiff.gradient(Bmag, x)
@@ -223,8 +223,8 @@ function trace_gc!(dy, y, p::GCTuple, t)
 	q, m, μ, Efunc, Bfunc = p
 	q2m = q / m
 	X = y[SA[1:3...]]
-	E = SVector{3}(Efunc(X, t))
-	B = SVector{3}(Bfunc(X, t))
+	E = Efunc(X, t)
+	B = Bfunc(X, t)
 	b̂ = normalize(B) # unit B field at X
 
 	Bmag(x) = √(Bfunc(x) ⋅ Bfunc(x))

--- a/src/prepare.jl
+++ b/src/prepare.jl
@@ -60,10 +60,14 @@ GCTuple = Tuple{Float64, Float64, Float64, AbstractField, AbstractField}
 
 
 """
-	 prepare(grid::CartesianGrid, E, B; kwargs...) -> (q2m, E, B)
+	prepare(args...; kwargs...) -> (q2m, m, E, B, F)
+	prepare(E, B, F = ZeroField(); kwargs...)
 
-Return a tuple consists of particle charge-mass ratio for a prescribed `species` and
-interpolated EM field functions.
+Return a tuple consists of particle charge-mass ratio for a prescribed `species` of charge `q` and mass `m`,
+	mass `m` for a prescribed `species`, analytic/interpolated EM field functions, and external force `F`.
+
+Prescribed `species` are `Electron` and `Proton`; 
+	other species can be manually specified with `species=Ion/User`, `q` and `m`.
 
 # Keywords
 - `order::Int=1`: order of interpolation in [1,2,3].
@@ -72,30 +76,20 @@ interpolated EM field functions.
 - `q::AbstractFloat=1.0`: particle charge. Only works when `Species=User`.
 - `m::AbstractFloat=1.0`: particle mass. Only works when `Species=User`.
 
-	 prepare(grid::CartesianGrid, E, B, F; species=Proton, q=1.0, m=1.0) -> (q, m, E, B, F)
+	 prepare(grid::CartesianGrid, E, B; kwargs...)
+	 prepare(grid::CartesianGrid, E, B, F; species=Proton, q=1.0, m=1.0)
 
 Return a tuple consists of particle charge, mass for a prescribed `species` of charge `q`
 and mass `m`, interpolated EM field functions, and external force `F`.
 
-	 prepare(x::AbstractRange, y::AbstractRange, z::AbstractRange, E, B; kwargs...) -> (q2m, E, B)
-	 prepare(x, y, E, B; kwargs...) -> (q2m, E, B)
+	 prepare(x::AbstractRange, y::AbstractRange, z::AbstractRange, E, B; kwargs...)
+	 prepare(x, y, E, B; kwargs...)
 
-	 prepare(x::AbstractRange, E, B; kwargs...) -> (q2m, E, B)
+	 prepare(x::AbstractRange, E, B; kwargs...)
 
 1D grid. An additional keyword `dir` is used for specifying the spatial direction, 1 -> x, 2 -> y, 3 -> z.
 
 Direct range input for uniform grid in 2/3D is also accepted.
-
-	 prepare(E, B; kwargs...) -> (q2m, E, B)
-
-Return a tuple consists of particle charge-mass ratio for a prescribed `species` of charge
-`q` and mass `m` and analytic EM field functions. Prescribed `species` are `Electron` and
-`Proton`; other species can be manually specified with `species=Ion/User`, `q` and `m`.
-
-	 prepare(E, B, F; kwargs...) -> (q, m, E, B, F)
-
-Return a tuple consists of particle charge, mass for a prescribed `species` of charge `q`
-and mass `m`, analytic EM field functions, and external force `F`.
 """
 function prepare(grid::CartesianGrid, E::TE, B::TB; species::Species = Proton,
 	q::AbstractFloat = 1.0, m::AbstractFloat = 1.0, order::Int = 1, bc::Int = 1,
@@ -113,7 +107,7 @@ function prepare(grid::CartesianGrid, E::TE, B::TB; species::Species = Proton,
 		B = TB <: AbstractArray ? getinterp(B, gridx, gridy, order, bc) : B
 	end
 
-	q/m, Field(E), Field(B)
+	q/m, m, Field(E), Field(B)
 end
 
 function prepare(grid::CartesianGrid, E::TE, B::TB, F::TF; species::Species = Proton,
@@ -128,7 +122,7 @@ function prepare(grid::CartesianGrid, E::TE, B::TB, F::TF; species::Species = Pr
 	B = TB <: AbstractArray ? getinterp(B, gridx, gridy, gridz, order, bc) : B
 	F = TF <: AbstractArray ? getinterp(F, gridx, gridy, gridz, order, bc) : F
 
-	q, m, Field(E), Field(B), Field(F)
+	q/m, m, Field(E), Field(B), Field(F)
 end
 
 function prepare(x::T, y::T, E::TE, B::TB; species::Species = Proton,
@@ -140,7 +134,7 @@ function prepare(x::T, y::T, E::TE, B::TB; species::Species = Proton,
 	E = TE <: AbstractArray ? getinterp(E, x, y, order, bc) : E
 	B = TB <: AbstractArray ? getinterp(B, x, y, order, bc) : B
 
-	q/m, Field(E), Field(B)
+	q/m, m, Field(E), Field(B)
 end
 
 function prepare(x::T, E::TE, B::TB; species::Species = Proton, q::AbstractFloat = 1.0,
@@ -152,7 +146,7 @@ function prepare(x::T, E::TE, B::TB; species::Species = Proton, q::AbstractFloat
 	E = TE <: AbstractArray ? getinterp(E, x, order, bc; dir) : E
 	B = TB <: AbstractArray ? getinterp(B, x, order, bc; dir) : B
 
-	q/m, Field(E), Field(B)
+	q/m, m, Field(E), Field(B)
 end
 
 function prepare(x::T, y::T, z::T, E::TE, B::TB;
@@ -165,26 +159,14 @@ function prepare(x::T, y::T, z::T, E::TE, B::TB;
 	E = TE <: AbstractArray ? getinterp(E, x, y, z, order, bc) : E
 	B = TB <: AbstractArray ? getinterp(B, x, y, z, order, bc) : B
 
-	q/m, Field(E), Field(B)
+	q/m, m, Field(E), Field(B)
 end
 
-function prepare(
-	E,
-	B;
-	species::Species = Proton,
-	q::AbstractFloat = 1.0,
-	m::AbstractFloat = 1.0,
-)
-	q, m = getchargemass(species, q, m)
-
-	q/m, Field(E), Field(B)
-end
-
-function prepare(E, B, F; species::Species = Proton, q::AbstractFloat = 1.0,
+function prepare(E, B, F = ZeroField(); species::Species = Proton, q::AbstractFloat = 1.0,
 	m::AbstractFloat = 1.0)
 	q, m = getchargemass(species, q, m)
 
-	q, m, Field(E), Field(B), Field(F)
+	q/m, m, Field(E), Field(B), Field(F)
 end
 
 

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -111,7 +111,9 @@ Reference: [DTIC](https://apps.dtic.mil/sti/citations/ADA023511)
 """
 function update_velocity!(xv, paramBoris, param, dt, t)
 	(; v⁻, v′, v⁺, t_rotate, s_rotate, v⁻_cross_t, v′_cross_s) = paramBoris
-	q2m, E, B = param[1], param[2](xv, t), param[3](xv, t)
+	q2m, _, Efunc, Bfunc = param
+	E = Efunc(xv, t)
+	B = Bfunc(xv, t)
 	# t vector
 	for dim in 1:3
 		t_rotate[dim] = q2m*B[dim]*0.5*dt


### PR DESCRIPTION
Compared to #235 , we save extra 10 lines of typed code.

```
CodeInfo(
1 ── %1  = Base.getfield(p, 1)::Float64
│    %2  = $(Expr(:boundscheck, false))::Bool
└───       goto #5 if not %2
2 ── %4  = Base.sub_int(4, 1)::Int64
│    %5  = Base.bitcast(Base.UInt, %4)::UInt64
│    %6  = Base.getfield(y, :size)::Tuple{Int64}
│    %7  = $(Expr(:boundscheck, true))::Bool
│    %8  = Base.getfield(%6, 1, %7)::Int64
│    %9  = Base.bitcast(Base.UInt, %8)::UInt64
│    %10 = Base.ult_int(%5, %9)::Bool
└───       goto #4 if not %10
3 ──       goto #5
4 ── %13 = Core.tuple(4)::Tuple{Int64}
│          invoke Base.throw_boundserror(y::Vector{Float64}, %13::Tuple{Int64})::Union{}
└───       unreachable
5 ┄─ %16 = Base.getfield(y, :ref)::MemoryRef{Float64}
│    %17 = Base.memoryrefnew(%16, 4, false)::MemoryRef{Float64}
│    %18 = Base.memoryrefget(%17, :not_atomic, false)::Float64
└───       goto #6
6 ── %20 = $(Expr(:boundscheck, false))::Bool
└───       goto #10 if not %20
7 ── %22 = Base.sub_int(5, 1)::Int64
│    %23 = Base.bitcast(Base.UInt, %22)::UInt64
│    %24 = Base.getfield(y, :size)::Tuple{Int64}
│    %25 = $(Expr(:boundscheck, true))::Bool
│    %26 = Base.getfield(%24, 1, %25)::Int64
│    %27 = Base.bitcast(Base.UInt, %26)::UInt64
│    %28 = Base.ult_int(%23, %27)::Bool
└───       goto #9 if not %28
8 ──       goto #10
9 ── %31 = Core.tuple(5)::Tuple{Int64}
│          invoke Base.throw_boundserror(y::Vector{Float64}, %31::Tuple{Int64})::Union{}
└───       unreachable
10 ┄ %34 = Base.getfield(y, :ref)::MemoryRef{Float64}
│    %35 = Base.memoryrefnew(%34, 5, false)::MemoryRef{Float64}
│    %36 = Base.memoryrefget(%35, :not_atomic, false)::Float64
└───       goto #11
11 ─ %38 = $(Expr(:boundscheck, false))::Bool
└───       goto #15 if not %38
12 ─ %40 = Base.sub_int(6, 1)::Int64
│    %41 = Base.bitcast(Base.UInt, %40)::UInt64
│    %42 = Base.getfield(y, :size)::Tuple{Int64}
│    %43 = $(Expr(:boundscheck, true))::Bool
│    %44 = Base.getfield(%42, 1, %43)::Int64
│    %45 = Base.bitcast(Base.UInt, %44)::UInt64
│    %46 = Base.ult_int(%41, %45)::Bool
└───       goto #14 if not %46
13 ─       goto #15
14 ─ %49 = Core.tuple(6)::Tuple{Int64}
│          invoke Base.throw_boundserror(y::Vector{Float64}, %49::Tuple{Int64})::Union{}
└───       unreachable
15 ┄ %52 = Base.getfield(y, :ref)::MemoryRef{Float64}
│    %53 = Base.memoryrefnew(%52, 6, false)::MemoryRef{Float64}
│    %54 = Base.memoryrefget(%53, :not_atomic, false)::Float64
└───       goto #16
16 ─       goto #17
17 ─ %57 = Base.mul_float(%36, 1.0e-8)::Float64
│    %58 = Base.mul_float(%54, 0.0)::Float64
│    %59 = Base.sub_float(%57, %58)::Float64
│    %60 = Base.mul_float(%54, 0.0)::Float64
│    %61 = Base.mul_float(%18, 1.0e-8)::Float64
│    %62 = Base.sub_float(%60, %61)::Float64
│    %63 = Base.mul_float(%18, 0.0)::Float64
│    %64 = Base.mul_float(%36, 0.0)::Float64
│    %65 = Base.sub_float(%63, %64)::Float64
│    %66 = Base.mul_float(%1, %59)::Float64
│    %67 = Base.mul_float(%1, %62)::Float64
│    %68 = Base.mul_float(%1, %65)::Float64
│    %69 = StaticArrays.tuple(%18, %36, %54, %66, %67, %68)::NTuple{6, Float64}
│    %70 = %new(SVector{6, Float64}, %69)::SVector{6, Float64}
└───       return %70
) => SVector{6, Float64}
```