### PR TITLE
Use pull_request_target for Benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,23 +1,22 @@
 name: Benchmarks
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
-      - '!compathelper/**'
     paths-ignore:
       - 'README.md'
       - 'test/**'
       - 'docs/**'
       - 'examples/**'
 
+permissions:
+  pull-requests: write
+
 jobs:
     performance-guard:
         runs-on: ubuntu-latest
-        permissions:
-          contents: write
-          pull-requests: write
-          repository-projects: write
+
         steps:
             - uses: actions/checkout@v4
             - uses: julia-actions/setup-julia@v2
@@ -28,7 +27,7 @@ jobs:
               id: extract-package-name
               run: |
                 PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
-                echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+                echo "::set-output name=package_name::$PACKAGE_NAME"
             - name: Build AirspeedVelocity
               env:
                 JULIA_NUM_THREADS: 2


### PR DESCRIPTION
Yesterday when a contributor tried to submit PRs, all the benchmark workflows failed at posting the result comments. This PR tries to use `pull_request_target` instead of `pull_request` and also set the write permission on the script top level.