### PR TITLE
Refactor: Simplify Boris pusher with OhMyThreads.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Hongyang Zhou <hyzhou@umich.edu>, and Tiancheng Liu <liutc@mail.nank
 version = "0.14.2"
 
 [deps]
-ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
@@ -16,9 +15,9 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 
 [compat]
-ChunkSplitters = "3"
 Elliptic = "1"
 ForwardDiff = "0.10, 1"
 Interpolations = "0.14, 0.15, 0.16"
@@ -31,3 +30,4 @@ SpecialFunctions = "1.5, 2"
 StaticArrays = "1.2"
 Statistics = "1"
 julia = "1.9"
+OhMyThreads = "0.8"

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -11,7 +11,7 @@ using SciMLBase: AbstractODEProblem, AbstractODEFunction, AbstractODESolution, R
 using StaticArrays: SVector, @SMatrix, MVector, SA
 using Meshes: coords, spacing, paramdim, CartesianGrid
 using ForwardDiff
-using ChunkSplitters
+using OhMyThreads: tmap
 using PrecompileTools: @setup_workload, @compile_workload
 import Base: +, *, /, setindex!, getindex
 import LinearAlgebra: ×


### PR DESCRIPTION
Replaced `ChunkSplitters.jl` with `OhMyThreads.jl` for multithreading in the Boris pusher.

This commit refactors the Boris pusher's multithreading logic to use `OhMyThreads.jl`. The previous implementation relied on pre-allocating an empty vector of `TraceSolution`s and filling it in-place using `Threads.@threads` with `ChunkSplitters.jl`. The new implementation simplifies this by introducing a `_boris_trajectory` function that calculates a single trajectory. The multithreaded `_solve` function now uses `OhMyThreads.tmap` to apply this function in parallel, and the serial version uses a more readable list comprehension. This change eliminates the need for the `_boris!` and `_prepare` functions, resulting in cleaner and more idiomatic Julia code.