### PR TITLE
feat: Add support for non-uniform spherical mesh interpolation

### DIFF
--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -3,7 +3,7 @@ module TestParticle
 using LinearAlgebra: norm, ×, ⋅, diag
 using Statistics: mean, normalize
 using Interpolations: interpolate, extrapolate, scale, BSpline, Linear, Quadratic, Cubic,
-                      Line, OnCell, Periodic, Flat
+                      Line, OnCell, Periodic, Flat, Gridded
 using SciMLBase: AbstractODEProblem, AbstractODEFunction, AbstractODESolution, ReturnCode,
                  BasicEnsembleAlgorithm, EnsembleThreads, EnsembleSerial,
                  DEFAULT_SPECIALIZATION, ODEFunction,
@@ -27,7 +27,7 @@ export get_gyrofrequency,
        get_gyroperiod, get_gyroradius, get_velocity, get_energy,
        energy2velocity
 export orbit, monitor
-export TraceProblem
+export TraceProblem, Cartesian, Spherical, SphericalNonUniformR
 
 """
 Type for the particles, `Proton`, `Electron`, `Ion`, or `User`.

--- a/src/gc.jl
+++ b/src/gc.jl
@@ -7,8 +7,8 @@ function prepare_gc(xv, xrange::T, yrange::T, zrange::T, E::TE, B::TB;
    q, m = getchargemass(species, q, m)
    x, v = xv[SA[1:3...]], xv[SA[4:6...]]
 
-   E = TE <: AbstractArray ? getinterp(E, xrange, yrange, zrange, order, bc) : E
-   B = TB <: AbstractArray ? getinterp(B, xrange, yrange, zrange, order, bc) : B
+   E = TE <: AbstractArray ? getinterp(Cartesian(), E, xrange, yrange, zrange, order, bc) : E
+   B = TB <: AbstractArray ? getinterp(Cartesian(), B, xrange, yrange, zrange, order, bc) : B
 
    bparticle = B(x)
    Bmag_particle = √(bparticle[1]^2 + bparticle[2]^2 + bparticle[3]^2)

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -216,7 +216,7 @@ end
 """
 Prepare for advancing.
 """
-function _prepare(prob, trajectories, dt, savestepinterval)
+function _prepare(prob::TraceProblem, trajectories, dt, savestepinterval)
    ttotal = prob.tspan[2] - prob.tspan[1]
    nt = round(Int, ttotal / dt) |> abs
    nout = nt ÷ savestepinterval + 1

--- a/src/utility/dipole.jl
+++ b/src/utility/dipole.jl
@@ -35,7 +35,7 @@ where r is the radial distance (in planetary radii) to a point on the line,
 λ is its co-latitude, and L is the L-shell of interest.
 """
 function dipole_fieldline(ϕ::Float64, L::Float64 = 2.5, nP::Int = 100)
-   xyz = [sph2cart(L*sin(θ)^2, ϕ, θ) for θ in range(-π, stop = π, length = nP)]
+   xyz = [sph2cart(L*sin(θ)^2, θ, ϕ) for θ in range(0, stop = π, length = nP)]
    x = Vector{Float64}(undef, length(xyz))
    y = Vector{Float64}(undef, length(xyz))
    z = Vector{Float64}(undef, length(xyz))

--- a/src/utility/interpolation.jl
+++ b/src/utility/interpolation.jl
@@ -1,9 +1,22 @@
 # Field interpolations.
 
+"Type for grid."
+abstract type Grid end
+"Cartesian grid."
+struct Cartesian <: Grid end
+"Spherical grid with uniform r, θ and ϕ."
+struct Spherical <: Grid end
+"Spherical grid with non-uniform r and uniform θ, ϕ."
+struct SphericalNonUniformR <: Grid end
+
+getinterp(A, grid1, grid2, grid3, args...) = getinterp(Cartesian(), A, grid1, grid2, grid3, args...)
+getinterp(A, grid1, grid2, args...) = getinterp(Cartesian(), A, grid1, grid2, args...)
+getinterp(A, grid1, args...) = getinterp(Cartesian(), A, grid1, args...)
+
+getinterp_scalar(A, grid1, grid2, grid3, args...) = getinterp_scalar(Cartesian(), A, grid1, grid2, grid3, args...)
+
 """
-     getinterp(A, gridx, gridy, gridz, order::Int=1, bc::Int=1)
-     getinterp(A, gridx, gridy, order::Int=1, bc::Int=1)
-     getinterp(A, gridx, order::Int=1, bc::Int=1, dir::Int=1)
+     getinterp(::Grid, A, gridx, gridy, gridz, order::Int=1, bc::Int=1)
 
 Return a function for interpolating field array `A` on the grid given by `gridx`, `gridy`,
 and `gridz`.
@@ -14,7 +27,7 @@ and `gridz`.
   - `bc::Int=1`: type of boundary conditions, 1 -> NaN, 2 -> periodic, 3 -> Flat.
   - `dir::Int`: 1/2/3, representing x/y/z direction.
 """
-function getinterp(A, gridx, gridy, gridz, order::Int = 1, bc::Int = 1)
+function getinterp(::Cartesian, A, gridx, gridy, gridz, order::Int = 1, bc::Int = 1)
    @assert size(A, 1) == 3 && ndims(A) == 4 "Inconsistent 3D force field and grid!"
 
    Ax = @view A[1, :, :, :]
@@ -37,7 +50,67 @@ function getinterp(A, gridx, gridy, gridz, order::Int = 1, bc::Int = 1)
    return get_field
 end
 
-function getinterp(A, gridx, gridy, order::Int = 1, bc::Int = 2)
+function getinterp(::Spherical, A, gridr, gridθ, gridϕ, order::Int = 1, bc::Int = 1)
+   @assert size(A, 1) == 3 && ndims(A) == 4 "Inconsistent 3D force field and grid!"
+
+   Ar = @view A[1, :, :, :]
+   Aθ = @view A[2, :, :, :]
+   Aϕ = @view A[3, :, :, :]
+
+   itpr, itpθ, itpϕ = _getinterp(Ar, Aθ, Aϕ, order, bc)
+
+   interpr = scale(itpr, gridr, gridθ, gridϕ)
+   interpθ = scale(itpθ, gridr, gridθ, gridϕ)
+   interpϕ = scale(itpϕ, gridr, gridθ, gridϕ)
+
+   # Return field value at a given location.
+   function get_field(xu)
+      r_val, θ_val, ϕ_val = cart2sph(xu[1], xu[2], xu[3])
+
+      Br = interpr(r_val, θ_val, ϕ_val)
+      Bθ = interpθ(r_val, θ_val, ϕ_val)
+      Bϕ = interpϕ(r_val, θ_val, ϕ_val)
+
+      Bx, By, Bz = sph_to_cart_vector(Br, Bθ, Bϕ, θ_val, ϕ_val)
+
+      return SA[Bx, By, Bz]
+   end
+
+   return get_field
+end
+
+function getinterp(::SphericalNonUniformR, A, gridr, gridθ, gridϕ, order::Int = 1, bc::Int = 1)
+   @assert size(A, 1) == 3 && ndims(A) == 4 "Inconsistent 3D force field and grid!"
+
+   Ar = @view A[1, :, :, :]
+   Aθ = @view A[2, :, :, :]
+   Aϕ = @view A[3, :, :, :]
+
+   if order != 1
+      throw(ArgumentError("Only linear interpolation is supported for non-uniform spherical grids!"))
+   end
+
+   itpr = extrapolate(interpolate((gridr, gridθ, gridϕ), Ar, Gridded(Linear())), Flat())
+   itpθ = extrapolate(interpolate((gridr, gridθ, gridϕ), Aθ, Gridded(Linear())), Flat())
+   itpϕ = extrapolate(interpolate((gridr, gridθ, gridϕ), Aϕ, Gridded(Linear())), Flat())
+
+   # Return field value at a given location.
+   function get_field(xu)
+      r_val, θ_val, ϕ_val = cart2sph(xu[1], xu[2], xu[3])
+
+      Br = itpr(r_val, θ_val, ϕ_val)
+      Bθ = itpθ(r_val, θ_val, ϕ_val)
+      Bϕ = itpϕ(r_val, θ_val, ϕ_val)
+
+      Bx, By, Bz = sph_to_cart_vector(Br, Bθ, Bϕ, θ_val, ϕ_val)
+
+      return SA[Bx, By, Bz]
+   end
+
+   return get_field
+end
+
+function getinterp(::Cartesian, A, gridx, gridy, order::Int = 1, bc::Int = 2)
    @assert size(A, 1) == 3 && ndims(A) == 3 "Inconsistent 2D force field and grid!"
 
    Ax = @view A[1, :, :]
@@ -60,7 +133,7 @@ function getinterp(A, gridx, gridy, order::Int = 1, bc::Int = 2)
    return get_field
 end
 
-function getinterp(A, gridx, order::Int = 1, bc::Int = 3; dir = 1)
+function getinterp(::Cartesian, A, gridx, order::Int = 1, bc::Int = 3; dir = 1)
    @assert size(A, 1) == 3 && ndims(A) == 2 "Inconsistent 1D force field and grid!"
 
    Ax = @view A[1, :]
@@ -136,7 +209,7 @@ function _getinterp(Ax, Ay, Az, order::Int, bc::Int)
 end
 
 """
-     getinterp_scalar(A, gridx, gridy, gridz, order::Int=1, bc::Int=1)
+     getinterp_scalar(::Grid, A, gridx, gridy, gridz, order::Int=1, bc::Int=1)
 
 Return a function for interpolating scalar array `A` on the grid given by `gridx`, `gridy`,
 and `gridz`. Currently only 3D arrays are supported.
@@ -147,7 +220,7 @@ and `gridz`. Currently only 3D arrays are supported.
   - `bc::Int=1`: type of boundary conditions, 1 -> NaN, 2 -> periodic, 3 -> Flat.
   - `dir::Int`: 1/2/3, representing x/y/z direction.
 """
-function getinterp_scalar(A, gridx, gridy, gridz, order::Int = 1, bc::Int = 1)
+function getinterp_scalar(::Cartesian, A, gridx, gridy, gridz, order::Int = 1, bc::Int = 1)
    itp = _getinterp_scalar(A, order, bc)
 
    interp = scale(itp, gridx, gridy, gridz)
@@ -157,6 +230,38 @@ function getinterp_scalar(A, gridx, gridy, gridz, order::Int = 1, bc::Int = 1)
       r = @view xu[1:3]
 
       return interp(r...)
+   end
+
+   return get_field
+end
+
+function getinterp_scalar(::Spherical, A, gridr, gridθ, gridϕ, order::Int = 1, bc::Int = 1)
+   itp = _getinterp_scalar(A, order, bc)
+
+   interp = scale(itp, gridr, gridθ, gridϕ)
+
+   # Return field value at a given location.
+   function get_field(xu)
+      r_val, θ_val, ϕ_val = cart2sph(xu[1], xu[2], xu[3])
+
+      return interp(r_val, θ_val, ϕ_val)
+   end
+
+   return get_field
+end
+
+function getinterp_scalar(::SphericalNonUniformR, A, gridr, gridθ, gridϕ, order::Int = 1, bc::Int = 1)
+   if order != 1
+      throw(ArgumentError("Only linear interpolation is supported for non-uniform spherical grids!"))
+   end
+
+   itp = extrapolate(interpolate((gridr, gridθ, gridϕ), A, Gridded(Linear())), Flat())
+
+   # Return field value at a given location.
+   function get_field(xu)
+      r_val, θ_val, ϕ_val = cart2sph(xu[1], xu[2], xu[3])
+
+      return itp(r_val, θ_val, ϕ_val)
    end
 
    return get_field

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -3,7 +3,28 @@
 """
 Convert from spherical to Cartesian coordinates vector.
 """
-sph2cart(r, ϕ, θ) = r*[sin(θ)*cos(ϕ), sin(θ)*sin(ϕ), cos(θ)]
+sph2cart(r, θ, ϕ) = r*[sin(θ)*cos(ϕ), sin(θ)*sin(ϕ), cos(θ)]
+
+"""
+Convert from Cartesian to spherical coordinates vector.
+"""
+function cart2sph(x, y, z)
+   r = √(x^2 + y^2 + z^2)
+   if r == 0
+      return 0.0, 0.0, 0.0
+   end
+   θ = acos(z/r)
+   ϕ = atan(y, x)
+   return r, θ, ϕ
+end
+
+"Convert a vector from spherical to Cartesian."
+function sph_to_cart_vector(vr, vθ, vϕ, θ, ϕ)
+   vx = sin(θ)*cos(ϕ)*vr + cos(θ)*cos(ϕ)*vθ - sin(ϕ)*vϕ
+   vy = sin(θ)*sin(ϕ)*vr + cos(θ)*sin(ϕ)*vθ + cos(ϕ)*vϕ
+   vz = cos(θ)*vr - sin(θ)*vθ
+   return vx, vy, vz
+end
 
 include("constants.jl")
 include("current_sheet.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,6 +104,38 @@ end
          nfunc33 = TP.getinterp_scalar(n, x, y, z, 3, 3)
          @test nfunc33(SA[20, 0, 0]) == 12.191176470588236
       end
+
+      begin # spherical interpolation
+         r = range(0, 10, length = 11)
+         θ = range(0, π, length = 11)
+         ϕ = range(0, 2π, length = 11)
+         # Vector field
+         B = fill(0.0, 3, length(r), length(θ), length(ϕ))
+         B[1,:,:,:] .= 1.0
+         Bfunc = TP.getinterp(TP.Spherical(), B, r, θ, ϕ)
+         @test Bfunc(SA[1,1,1]) ≈ [0.57735, 0.57735, 0.57735] atol=1e-5
+         # Scalar field
+         A = ones(length(r), length(θ), length(ϕ))
+         Afunc = TP.getinterp_scalar(TP.Spherical(), A, r, θ, ϕ)
+         @test Afunc(SA[1,1,1]) == 1.0
+         @test Afunc(SA[0,0,0]) == 1.0
+      end
+
+      begin # non-uniform spherical interpolation
+         r = logrange(1.0, 10.0, length=11)
+         θ = range(0, π, length = 11)
+         ϕ = range(0, 2π, length = 11)
+         # Vector field
+         B = fill(0.0, 3, length(r), length(θ), length(ϕ))
+         B[1,:,:,:] .= 1.0
+         Bfunc = TP.getinterp(TP.SphericalNonUniformR(), B, r, θ, ϕ)
+         @test Bfunc(SA[1,1,1]) ≈ [0.57735, 0.57735, 0.57735] atol=1e-5
+         # Scalar field
+         A = ones(length(r), length(θ), length(ϕ))
+         Afunc = TP.getinterp_scalar(TP.SphericalNonUniformR(), A, r, θ, ϕ)
+         @test Afunc(SA[1,1,1]) == 1.0
+         @test Afunc(SA[0,0,0]) == 1.0
+      end
    end
 
    @testset "numerical field" begin
@@ -190,16 +222,16 @@ end
       Rₑ = TP.Rₑ
 
       # initial velocity, [m/s]
-      v₀ = TP.sph2cart(energy2velocity(Ek; q, m), 0.0, π/4)
+      v₀ = TP.sph2cart(energy2velocity(Ek; q, m), π/4, 0.0)
       # initial position, [m]
-      r₀ = TP.sph2cart(2.5*Rₑ, 0.0, π/2)
+      r₀ = TP.sph2cart(2.5*Rₑ, π/2, 0.0)
       stateinit = [r₀..., v₀...]
       tspan = (0.0, 1.0)
 
       @test sum(TP.getB_CS_harris(
          [1.0, 0.0, 1.0], 1.0, 1.0, 2.0)) == 2.761594155955765
 
-      @test TP.dipole_fieldline(0.0, 2.0, 2)[1][1] == -3.673352034653548e-48
+      @test TP.dipole_fieldline(0.0, 2.0, 2)[1][1] ≈ 0.0 atol=1e-40
       @test TP.getB_tokamak_coil(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)[1] ==
             -1.196424672603716e-6
       q_profile(nr) = nr^2 + 2*nr + 0.5


### PR DESCRIPTION
This change adds support for spherical mesh interpolation to the TestParticle.jl package. It includes the necessary coordinate and vector transformations, as well as a new grid-type dispatch system to handle different grid types.