### PR TITLE
Fix dead cross-references in documentation demos

### DIFF
--- a/docs/examples/advanced/demo_analytic_magnetosphere.jl
+++ b/docs/examples/advanced/demo_analytic_magnetosphere.jl
@@ -1,7 +1,7 @@
 # Analytical Magnetosphere
 #
 # This demo shows how to trace particles in a vacuum superposition of a dipolar magnetic field ``\mathbf{B}_D`` with a uniform background magnetic field ``\mathbf{B}_\mathrm{IMF}``.
-# In this slightly modified dipole field, magnetic null points appear near 14 Earth's radii, and the particle orbits are also distorted from the idealized motions in [Demo: magnetic dipole](@ref demo_dipole).
+# In this slightly modified dipole field, magnetic null points appear near 14 Earth's radii, and the particle orbits are also distorted from the idealized motions in [Demo: magnetic dipole](@ref Magnetic-Dipole).
 
 import DisplayAs #hide
 using TestParticle, OrdinaryDiffEqVerner, StaticArrays

--- a/docs/examples/advanced/demo_boris_outofdomain.jl
+++ b/docs/examples/advanced/demo_boris_outofdomain.jl
@@ -2,7 +2,7 @@
 #
 # This example shows how to trace charged particles using the Boris method in dimensionless units with additionally boundary check.
 # If the particles travel out of the domain specified by the field, the tracing will stop.
-# Check [Demo: Dimensionless Units](@ref demo_dimensionless) for explaining the unit conversion, and [Demo: Boris Method](@ref demo_boris) for introducing the Boris method.
+# Check [Demo: Dimensionless Units](@ref Dimensionless-Units) for explaining the unit conversion, and [Demo: Boris Method](@ref Boris-Method) for introducing the Boris method.
 
 import DisplayAs #hide
 using TestParticle, OrdinaryDiffEqVerner, StaticArrays

--- a/docs/examples/advanced/demo_ensemble.jl
+++ b/docs/examples/advanced/demo_ensemble.jl
@@ -55,7 +55,7 @@ end
 
 f = DisplayAs.PNG(f) #hide
 
-# We can also solve this problem with the native [Boris pusher](@ref demo_boris).
+# We can also solve this problem with the native [Boris pusher](@ref Boris-Method).
 # Note that the Boris pusher requires a additional parameters: a fixed timestep, and an output save interval.
 
 dt = 0.1

--- a/docs/examples/advanced/demo_gpu.md
+++ b/docs/examples/advanced/demo_gpu.md
@@ -1,7 +1,7 @@
 
 # GPU Ensemble tracing
 
-This example demonstrates the usage of GPU for [ensemble tracing](@ref demo_ensemble).
+This example demonstrates the usage of GPU for [ensemble tracing](@ref Ensemble-Tracing).
 Since GitHub Actions do not have GPU runners for now, we do not show the results on page.
 
 ```julia

--- a/docs/examples/advanced/demo_output_func.jl
+++ b/docs/examples/advanced/demo_output_func.jl
@@ -1,8 +1,8 @@
 # # Ensemble Tracing with Extra Saving
 #
 # This example demonstrates tracing multiple protons in an analytic E field and numerical B field.
-# See [Demo: single tracing with additional diagnostics](@ref demo_savingcallback) for explaining the unit conversion.
-# Also check [Demo: Ensemble](@ref demo_ensemble) for basic usages of the ensemble problem.
+# See [Demo: single tracing with additional diagnostics](@ref Additional-Diagnostics) for explaining the unit conversion.
+# Also check [Demo: Ensemble](@ref Ensemble-Tracing) for basic usages of the ensemble problem.
 
 # The `output_func` argument can be used to change saving outputs.
 # It works as a reduction function, but here we demonstrate how to add additional outputs.

--- a/docs/examples/advanced/demo_savingcallback.jl
+++ b/docs/examples/advanced/demo_savingcallback.jl
@@ -11,7 +11,7 @@
 # However, we cannot simply shrink the spatial coordinates as we wish, otherwise we will quickly encounter the boundary of our simulation.
 
 # The `SavingCallback` from DiffEqCallbacks.jl can be used to save additional outputs for diagnosis. Here we save the magnetic field along the trajectory, together with the parallel velocity.
-# Note that `SavingCallback` is currently not compatible with ensemble problems; for multiple particle tracing with customized outputs, see [Demo: ensemble tracing with extra saving](@ref demo_output_func).
+# Note that `SavingCallback` is currently not compatible with ensemble problems; for multiple particle tracing with customized outputs, see [Demo: ensemble tracing with extra saving](@ref Ensemble-Tracing-with-Extra-Saving).
 
 using TestParticle, OrdinaryDiffEqVerner, StaticArrays
 using TestParticle: qᵢ, mᵢ

--- a/docs/examples/advanced/demo_spherical.jl
+++ b/docs/examples/advanced/demo_spherical.jl
@@ -1,7 +1,7 @@
 # # Spherical Coordinates
 #
 # This example demonstrates a single proton motion under a uniform B field defined in
-# spherical coordinates following the same values in [Demo: Helix motion](@ref demo_uniformB_zeroE). The E field is set to zero.
+# spherical coordinates following the same values in [Demo: Helix motion](@ref Helix-Motion). The E field is set to zero.
 
 import DisplayAs #hide
 import TestParticle as TP

--- a/docs/examples/basics/demo_dimensionless.jl
+++ b/docs/examples/basics/demo_dimensionless.jl
@@ -4,7 +4,7 @@
 # After normalization, ``q=1, B=1, m=1`` so that the gyroradius ``r_L = mv_\perp/qB = v_\perp``.
 # All the quantities are given in dimensionless units: if the magnetic field is homogeneous and the initial perpendicular velocity ``v_{\perp 0}^\prime`` is 4, then the gyroradius is 4.
 # To convert them to the original units, ``v_\perp = v_{\perp}^\prime * U_0`` and ``r_L = r_L^\prime * l_0 = 4*l_0``.
-# Check [Demo: single tracing with additional diagnostics](@ref demo_savingcallback) and [Demo: Dimensionless and Dimensional Tracing](@ref demo_dimensionless_dimensional) for explaining the unit conversion.
+# Check [Demo: single tracing with additional diagnostics](@ref Additional-Diagnostics) and [Demo: Dimensionless and Dimensional Tracing](@ref Dimensionless-and-Dimensional-Tracing) for explaining the unit conversion.
 
 # Tracing in dimensionless units is beneficial for many scenarios. For example, MHD simulations do not have intrinsic scales. Therefore, we can do dimensionless particle tracing in MHD fields, and then convert to any scale we would like.
 

--- a/docs/examples/basics/demo_dimensionless_periodic.jl
+++ b/docs/examples/basics/demo_dimensionless_periodic.jl
@@ -1,7 +1,7 @@
 # # Tracing with Dimensionless Units and Periodic Boundary
 #
 # This example shows how to trace charged particles in dimensionless units and EM fields with periodic boundaries in a 2D spatial domain.
-# For details about dimensionless units, please check [Demo: dimensionless tracing](@ref demo_dimensionless).
+# For details about dimensionless units, please check [Demo: dimensionless tracing](@ref Dimensionless-Units).
 
 # Now let's demonstrate this with `trace_normalized!`.
 

--- a/docs/examples/basics/demo_gradient_B.jl
+++ b/docs/examples/basics/demo_gradient_B.jl
@@ -2,7 +2,7 @@
 #
 # This example demonstrates a single proton motion under a non-uniform B field with gradient ∇B ⊥ B.
 # The orbit of guiding center includes some high order terms, it is different from the formula of magnetic field gradient drift of some textbooks which just preserves the first order term.
-# It is more complex than the simpler [ExB drift](@ref demo_ExB).
+# It is more complex than the simpler [ExB drift](@ref EB-Drift).
 # More theoretical details can be found in [Grad-B Drift](https://henry2004y.github.io/KeyNotes/contents/single.html#b-b-grad-b-drift), and Fundamentals of Plasma Physics by Paul Bellan.
 
 import DisplayAs #hide


### PR DESCRIPTION
Updated broken cross-references in `docs/examples/` to use correct `Documenter.jl` anchor IDs derived from section headers.