### PR TITLE
Update docstrings for gyro-related utility functions

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,7 +5,3 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TestParticle = "953b605b-f162-4481-8f7f-a191c2bb40e3"
-
-[sources]
-TestParticle = {path = ".."}


### PR DESCRIPTION
Detailed descriptions for input arguments `V` (velocity), `B` (magnetic field), `q` (charge), and `m` (mass) were added, including their physical units. This clarifies the usage of these functions.