### PR TITLE
Switch Boris initialization back to backward Boris step

### DIFF
--- a/src/multistep_boris.jl
+++ b/src/multistep_boris.jl
@@ -121,17 +121,8 @@ function _multistep_boris!(
       xv .= new_prob.u0
       traj[1] = copy(xv) # Initial condition is saved before the loop
 
-      # push velocity back in time by 1/2 dt using Euler step
-      # v(-1/2) = v(0) - q/m * (E(0) + v(0) x B(0)) * dt/2
-      q2m, _, Efunc, Bfunc = p
-      t0 = tspan[1]
-      E = Efunc(xv, t0)
-      B = Bfunc(xv, t0)
-      v = @view xv[4:6]
-      cross!(v, B, paramBoris.v_cross_t) # v x B stored in v_cross_t
-      for dim in 1:3
-         xv[dim + 3] -= q2m * (E[dim] + paramBoris.v_cross_t[dim]) * 0.5 * dt
-      end
+      # push velocity back in time by 1/2 dt
+      update_velocity_multistep!(xv, paramBoris, p, -0.5 * dt, tspan[1], n_steps)
 
       v_old = MVector{3, eltype(u0)}(undef)
       iout = 1

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -258,16 +258,7 @@ function _boris!(sols, prob, irange, savestepinterval, dt, nt, nout, isoutofdoma
       traj[1] = copy(xv) # Initial condition is saved before the loop
 
       # push velocity back in time by 1/2 dt
-      # Euler step: v(-1/2) = v(0) - q/m * (E(0) + v(0) x B(0)) * dt/2
-      q2m, _, Efunc, Bfunc = p
-      t0 = tspan[1]
-      E = Efunc(xv, t0)
-      B = Bfunc(xv, t0)
-      v = @view xv[4:6]
-      cross!(v, B, paramBoris.v⁻_cross_t) # v x B stored in v⁻_cross_t
-      for dim in 1:3
-         xv[dim + 3] -= q2m * (E[dim] + paramBoris.v⁻_cross_t[dim]) * 0.5 * dt
-      end
+      update_velocity!(xv, paramBoris, p, -0.5 * dt, tspan[1])
 
       iout = 1
       it = 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -508,25 +508,25 @@ end
 
       sol = TP.solve(prob; dt, savestepinterval = 10)[1]
 
-      @test sol.u[end] == [-0.00010202703809031266, 3.4645613379533876e-5, 0.0,
-         -64990.810956836205, -76001.27953641811, 0.0]
+      @test sol.u[end] == [-0.00010199139098074829, 3.4634030517007745e-5, 0.0,
+         -64968.55371149313, -75974.54581682774, 0.0]
       @test length(sol.t) == length(sol.u)
 
       t = tspan[2] / 2
-      @test sol(t) == [-3.860156535091208e-5, 5.3874472219981494e-5, 0.0,
-         -94689.5940564516, 32154.016505320047, 0.0]
+      @test sol(t) == [-3.8587891411024776e-5, 5.3855910044312875e-5, 0.0,
+         -94656.51056802433, 32143.266643605573, 0.0]
 
       prob = TraceProblem(stateinit, tspan, param; prob_func = prob_func_boris_immutable)
       trajectories = 4
       savestepinterval = 1000
       sols = TP.solve(prob, EnsembleThreads(); dt, savestepinterval, trajectories)
-      @test sum(s -> sum(s.u[end][4]), sols) ≈ -649908.1095683626
+      @test sum(s -> sum(s.u[end][4]), sols) ≈ -649685.5371149312
 
       prob = TraceProblem(stateinit, tspan, param; prob_func = prob_func_boris_immutable)
       trajectories = 2
       savestepinterval = 1000
       sols = TP.solve(prob; dt, savestepinterval, trajectories)
-      @test sum(s -> sum(s.u[end]), sols) ≈ -422976.2716819072
+      @test sum(s -> sum(s.u[end]), sols) ≈ -422829.29878703464
 
       x0 = [-1.0, 0.0, 0.0]
       v0 = [1e6, 0.0, 0.0]

--- a/test/test_multistep_boris.jl
+++ b/test/test_multistep_boris.jl
@@ -56,16 +56,16 @@ using StaticArrays
    @test hypot(@views sol_4step_gyro[1].u[end][1:3]...) < 0.02
 
    # Energy conservation check (E=0 implies |v| is constant)
-   # Euler initialization adds a small energy error: v(-1/2) = v(0) - a*dt/2
-   # |v(-1/2)|^2 = |v(0)|^2 + |a|^2 * dt^2/4
-   # a = q/m * v x B. |a| = 1 * 1 * 1 = 1.
-   # However, the output velocity is now averaged: v(n) = (v(n-1/2) + v(n+1/2))/2
-   # This averaging effectively corrects the magnitude error introduced by the staggered grid for gyromotion.
-   # |v(n)| ≈ |v(0)|
+   # The internal velocity preserves magnitude perfectly.
+   # However, the output velocity is averaged: v(n) = (v(n-1/2) + v(n+1/2))/2
+   # This averaging introduces a damping in magnitude for gyromotion: |v_out| = |v_in| * cos(alpha/2)
+   # where alpha is the rotation angle per step ~ omega_c * dt.
+   # For dt=0.1, omega_c=1, alpha ~ 0.1 rad. cos(0.05) ~ 0.99875.
+   # This damping is O(dt^2).
    v0_norm = hypot(@views u0_gyro[4:6]...)
 
    for sol in (sol_1step_gyro, sol_2step_gyro, sol_4step_gyro)
       v_end = @view sol[1].u[end][4:6]
-      @test hypot(v_end...) ≈ v0_norm atol=1e-5
+      @test hypot(v_end...) ≈ v0_norm atol=2e-3
    end
 end


### PR DESCRIPTION
Replaced the Euler step initialization in native Boris solvers (`_boris!` and `_multistep_boris!`) with a backward call to `update_velocity!` / `update_velocity_multistep!`. This ensures that the internal velocity magnitude is preserved during initialization, preventing artificial energy gain in pure magnetic fields.

Updates `test/runtests.jl` with new expected trajectory values reflecting the corrected initialization.
Updates `test/test_multistep_boris.jl` to account for the $O(dt^2)$ damping in output velocity magnitude caused by averaging, which is no longer masked by the initialization error.