### PR TITLE
Sync velocity output in Boris method

### DIFF
--- a/src/multistep_boris.jl
+++ b/src/multistep_boris.jl
@@ -137,14 +137,14 @@ function _multistep_boris!(
          v_old .= @view xv[4:6]
          update_velocity_multistep!(xv, paramBoris, p, dt, (it-0.5)*dt, n_steps)
 
-         if save_everystep && (it-1) > 0 && (it-1) % savestepinterval == 0
+         if save_everystep && (it - 1) > 0 && (it - 1) % savestepinterval == 0
             iout += 1
             if iout <= nout
                traj[iout] = copy(xv)
-               traj[iout][4] = (v_old[1] + xv[4]) / 2
-               traj[iout][5] = (v_old[2] + xv[5]) / 2
-               traj[iout][6] = (v_old[3] + xv[6]) / 2
-               tsave[iout] = tspan[1] + (it - 1) * dt
+               traj[iout][4:6] .= v_old
+               t_current = tspan[1] + (it - 1) * dt
+               update_velocity_multistep!(traj[iout], paramBoris, p, 0.5 * dt, t_current, n_steps)
+               tsave[iout] = t_current
             end
          end
 

--- a/src/pusher.jl
+++ b/src/pusher.jl
@@ -313,10 +313,10 @@ function _boris!(sols, prob, irange, savestepinterval, dt, nt, nout, isoutofdoma
             iout += 1
             if iout <= nout
                traj[iout] = copy(xv)
-               traj[iout][4] = (v_old[1] + xv[4]) / 2
-               traj[iout][5] = (v_old[2] + xv[5]) / 2
-               traj[iout][6] = (v_old[3] + xv[6]) / 2
-               tsave[iout] = tspan[1] + (it - 1) * dt
+               traj[iout][4:6] .= v_old
+               t_current = tspan[1] + (it - 1) * dt
+               update_velocity!(traj[iout], paramBoris, p, 0.5 * dt, t_current)
+               tsave[iout] = t_current
             end
          end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -513,8 +513,8 @@ end
       @test length(sol.t) == length(sol.u)
 
       t = tspan[2] / 2
-      @test sol(t) == [-3.8587891411024776e-5, 5.3855910044312875e-5, 0.0,
-         -94656.51056802433, 32143.266643605573, 0.0]
+      @test sol(t) ≈ [-3.8587891411024776e-5, 5.3855910044312875e-5, 0.0,
+         -94689.59405645168, 32154.016505320025, 0.0]
 
       prob = TraceProblem(stateinit, tspan, param; prob_func = prob_func_boris_immutable)
       trajectories = 4


### PR DESCRIPTION
Changed the velocity saving mechanism in the Boris method (both standard and multistep) to advance the velocity from the previous half-step ($v_{n-1/2}$) by exactly half a time step ($dt/2$) to obtain the synchronous velocity $v_n$.

Previously, the output velocity was calculated by averaging $v_{n-1/2}$ and $v_{n+1/2}$, which dampened the velocity magnitude (energy) for gyrating particles. The new method preserves energy more accurately in the output.

Updated `test/runtests.jl` to reflect the improved accuracy in the Boris pusher test case.

Handles #309.