### PR TITLE
feat: Add getB_loop for current coil magnetic fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ report.md
 !test/test_svector_interp.jl
 !test/test_save_flags.jl
 !test/
+!test/test_loop.jl

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -14,6 +14,7 @@ using Meshes: coords, spacing, paramdim, CartesianGrid
 using ForwardDiff
 using ChunkSplitters
 using PrecompileTools: @setup_workload, @compile_workload
+using Elliptic
 import Base: +, *, /, setindex!, getindex
 import LinearAlgebra: ×
 

--- a/src/utility/loop.jl
+++ b/src/utility/loop.jl
@@ -1,0 +1,77 @@
+# Magnetic field of a current loop.
+
+"""
+    getB_loop(r, R, a, I, n)
+
+Calculate the magnetic field `B` [T] at point `r` from a current loop with current `I` [A],
+radius `a` [m], centered at `R`, and normal vector `n`.
+
+# Arguments
+- `r::AbstractVector`: Position vector [x, y, z].
+- `R::AbstractVector`: Position of the loop center [x, y, z].
+- `a::Real`: Radius of the loop.
+- `I::Real`: Current in the loop.
+- `n::AbstractVector`: Normal vector of the loop (direction of the B-field at the center).
+"""
+function getB_loop(r::AbstractVector, R::AbstractVector, a::Real, I::Real, n::AbstractVector)
+   # Normalize the normal vector
+   n_hat = normalize(n)
+
+   # Relative position from center
+   r_rel = r - R
+
+   # Project r_rel onto the normal vector to get z component in local coordinates
+   z_local = dot(r_rel, n_hat)
+
+   # Vector component perpendicular to n (rho vector)
+   rho_vec = r_rel - z_local * n_hat
+   rho = norm(rho_vec)
+
+   # Handle the singularity on the wire itself (rho = a, z = 0)
+   # and the center (rho = 0) separately if needed.
+   # But standard formulas usually handle rho=0 if careful.
+
+   if rho < 1e-10 * a # On the axis
+      # B is purely in n direction
+      # B = \mu_0 I a^2 / (2 (a^2 + z^2)^(3/2))
+      B_mag = μ₀ * I * a^2 / (2 * (a^2 + z_local^2)^1.5)
+      return B_mag * n_hat
+   end
+
+   # Cylindrical components calculation
+   # B_rho and B_z in local coordinates
+   # Formulas from Jackson or similar standard texts
+
+   # k^2 = 4 a rho / ((a + rho)^2 + z^2)
+   denom_sq = (a + rho)^2 + z_local^2
+   k_sq = 4 * a * rho / denom_sq
+
+   K_val = Elliptic.K(k_sq)
+   E_val = Elliptic.E(k_sq)
+
+   # Common factor
+   factor = μ₀ * I / (2 * π * sqrt(denom_sq))
+
+   # B_z (local)
+   # B_z = factor * (K + (a^2 - rho^2 - z^2)/((a-rho)^2 + z^2) * E)
+   denom_diff_sq = (a - rho)^2 + z_local^2
+   B_z_local = factor * (K_val + (a^2 - rho^2 - z_local^2) / denom_diff_sq * E_val)
+
+   # B_rho (local)
+   # B_rho = factor * (z / rho) * (-K + (a^2 + rho^2 + z^2)/((a-rho)^2 + z^2) * E)
+   if abs(z_local) < 1e-15
+       B_rho_local = 0.0
+   else
+       B_rho_local = factor * (z_local / rho) * (-K_val + (a^2 + rho^2 + z_local^2) / denom_diff_sq * E_val)
+   end
+
+   # Transform back to global Cartesian coordinates
+   # B = B_rho * rho_hat + B_z * n_hat
+   # rho_hat = rho_vec / rho
+
+   rho_hat = rho_vec / rho
+
+   B = B_rho_local * rho_hat + B_z_local * n_hat
+
+   return B
+end

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -41,6 +41,7 @@ end
 include("constants.jl")
 include("current_sheet.jl")
 include("dipole.jl")
+include("loop.jl")
 include("confinement.jl")
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -599,6 +599,7 @@ end
 
 include("test_multistep_boris.jl")
 include("test_svector_interp.jl")
+include("test_loop.jl")
 
 #if "makie" in ARGS
 #   include("test_Makie.jl")

--- a/test/test_loop.jl
+++ b/test/test_loop.jl
@@ -1,0 +1,64 @@
+using TestParticle
+using Test
+using StaticArrays
+using LinearAlgebra
+using Elliptic
+
+@testset "Loop Field" begin
+   # Parameters
+   R = [0.0, 0.0, 0.0]
+   a = 1.0
+   I = 1.0
+   n = [0.0, 0.0, 1.0]
+
+   # Test field at the center
+   r_center = [0.0, 0.0, 0.0]
+   B_center = TestParticle.getB_loop(r_center, R, a, I, n)
+   # B = mu0 * I / (2 * a) in z direction
+   B_expected = TestParticle.μ₀ * I / (2 * a) * n
+   @test B_center ≈ B_expected atol=1e-15
+
+   # Test field on the axis
+   z = 2.0
+   r_axis = [0.0, 0.0, z]
+   B_axis = TestParticle.getB_loop(r_axis, R, a, I, n)
+   # B = mu0 * I * a^2 / (2 * (a^2 + z^2)^(3/2))
+   B_mag = TestParticle.μ₀ * I * a^2 / (2 * (a^2 + z^2)^1.5)
+   @test B_axis ≈ B_mag * n atol=1e-15
+
+   # Test arbitrary orientation
+   n_rot = [1.0, 0.0, 0.0]
+   B_center_rot = TestParticle.getB_loop(r_center, R, a, I, n_rot)
+   @test B_center_rot ≈ TestParticle.μ₀ * I / (2 * a) * n_rot atol=1e-15
+
+   # Test off-axis field consistency (check B_z at z=0 plane)
+   # For z=0, B_z = mu0*I/(2*pi*a) * K(k^2) ? No, let's use the formula.
+   # At z=0, B_rho = 0.
+   # We can check continuity or just that it runs without error and gives reasonable numbers.
+
+   r_off = [0.5, 0.0, 0.0]
+   B_off = TestParticle.getB_loop(r_off, R, a, I, n)
+   @test B_off[1] ≈ 0.0 atol=1e-15 # No radial component if z=0? Wait.
+   # If z=0, B_rho component:
+   # factor * (z / rho) * ... -> 0 because z=0. Correct.
+   # So B should be purely in z direction.
+   @test abs(B_off[3]) > 0.0
+
+   # Test rotated loop with off-axis point
+   # Rotate loop by 90 degrees around Y axis, normal becomes X.
+   n_x = [1.0, 0.0, 0.0]
+   # Point that was at [0, 0, 2] (z-axis) should now be at [2, 0, 0] (x-axis) relative to loop
+   r_x = [2.0, 0.0, 0.0]
+   B_x = TestParticle.getB_loop(r_x, R, a, I, n_x)
+
+   # Magnitude should match the previous axis test
+   @test norm(B_x) ≈ B_mag atol=1e-15
+   @test B_x ≈ B_mag * n_x atol=1e-15
+
+   # Test translated loop
+   R_new = [10.0, 10.0, 10.0]
+   r_new = R_new + [0.0, 0.0, 2.0] # 2.0 along z from center
+   B_trans = TestParticle.getB_loop(r_new, R_new, a, I, n)
+   @test B_trans ≈ B_mag * n atol=1e-15
+
+end


### PR DESCRIPTION
Added a new utility function `getB_loop` to calculate the magnetic field
of a current loop with arbitrary orientation using elliptic integrals.
This addresses Issue #165.

- Added `src/utility/loop.jl` with `getB_loop` implementation.
- Included `loop.jl` in `src/utility/utility.jl`.
- Moved `using Elliptic` to `src/TestParticle.jl` for package-wide availability (was already a dependency but now explicitly used for this feature).
- Added `test/test_loop.jl` to verify the implementation.
- Updated `test/runtests.jl` to include the new test.
- Updated `.gitignore` to un-ignore `test/test_loop.jl`.