### PR TITLE
Refactor energy ratio comparison in dipole demo to use a table

### DIFF
--- a/docs/examples/analytic/demo_proton_dipole.jl
+++ b/docs/examples/analytic/demo_proton_dipole.jl
@@ -68,7 +68,7 @@ end
 using Markdown
 using Printf
 
-results = []
+results = Tuple{String, Float64}[]
 
 ## OrdinaryDiffEq solvers
 ode_solvers = [


### PR DESCRIPTION
Replaced sequential `get_energy_ratio` calls with a loop over solver configurations and a consolidated Markdown table for clearer comparison. Included `StepsizeLimiter` and `Boris` method results in the table.