### PR TITLE
Fix flaky BiKappa test by increasing sample size

### DIFF
--- a/test/test_distributions.jl
+++ b/test/test_distributions.jl
@@ -60,7 +60,7 @@ using Test
    @test length(v_bss) == 3
 
    # Statistical tests (variance check)
-   N = 10000
+   N = 100000
 
    # Maxwellian Variance Check
    # Variance per component should be vth^2


### PR DESCRIPTION
The statistical variance check for the BiKappa distribution was occasionally failing on MacOS due to the heavy-tailed nature of the Kappa distribution and insufficient sample size (N=10000).

This change increases the sample size to N=100000 for all distribution tests, significantly reducing the standard deviation of the variance estimator and preventing flaky test failures. The relative tolerance remains at 0.05.