### PR TITLE
Add Z-pinch particle tracing demo

### DIFF
--- a/docs/examples/analytic/demo_zpinch.jl
+++ b/docs/examples/analytic/demo_zpinch.jl
@@ -1,0 +1,85 @@
+# # Proton in Z-pinch
+#
+# This example traces protons in a Z-pinch magnetic configuration.
+# The Z-pinch consists of a current flowing along the z-axis, creating an azimuthal magnetic field.
+# Reference: [Z-pinch](https://en.wikipedia.org/wiki/Z-pinch)
+
+import DisplayAs #hide
+using TestParticle, OrdinaryDiffEq, StaticArrays
+using CairoMakie
+CairoMakie.activate!(type = "png") #hide
+
+### Initialize Field
+
+## Z-pinch parameters
+const I_current = 1.0e6 # Current [A]
+const a_wire = 0.1 # Radius of the wire [m]
+
+function getB(xu)
+   x, y, z = xu[1], xu[2], xu[3]
+   getB_zpinch(x, y, z, I_current, a_wire)
+end
+
+function getE(xu)
+   SA[0.0, 0.0, 0.0]
+end
+
+### Initialize Particles
+
+## Protons
+const m = TestParticle.mᵢ
+const q = TestParticle.qᵢ
+const c = TestParticle.c
+
+## Initial state
+## Position inside the wire to see internal behavior, or outside.
+## Let's put one outside and one inside.
+r0_in = [0.05, 0.0, 0.0]
+v0_in = [0.0, 1e5, 1e5] # Spiral
+
+r0_out = [0.2, 0.0, 0.0]
+v0_out = [0.0, 1e6, 1e5] # Drift
+
+stateinit_in = [r0_in..., v0_in...]
+stateinit_out = [r0_out..., v0_out...]
+
+param = prepare(getE, getB; species = Proton)
+tspan = (0.0, 1e-5)
+
+prob_in = ODEProblem(trace!, stateinit_in, tspan, param)
+prob_out = ODEProblem(trace!, stateinit_out, tspan, param)
+
+sol_in = solve(prob_in, Vern9())
+sol_out = solve(prob_out, Vern9())
+
+### Visualization
+
+f = Figure(fontsize = 18)
+ax = Axis3(f[1, 1],
+   title = "Proton Trajectories in Z-pinch",
+   xlabel = "x [m]",
+   ylabel = "y [m]",
+   zlabel = "z [m]",
+   aspect = :data
+)
+
+lines!(ax, sol_in, label="Inside (r < a)", color=:blue)
+lines!(ax, sol_out, label="Outside (r > a)", color=:red)
+
+## Plot the wire boundary
+θ = range(0, 2π, length=100)
+zw = range(minimum(sol_out[3, :]), maximum(sol_out[3, :]), length=2)
+x_wire = a_wire .* cos.(θ)
+y_wire = a_wire .* sin.(θ)
+
+# Wire cylinder visualization (wireframe)
+lines!(ax, x_wire, y_wire, fill(zw[1], length(θ)), color=(:gray, 0.5))
+lines!(ax, x_wire, y_wire, fill(zw[2], length(θ)), color=(:gray, 0.5))
+# Vertical lines for wire
+for i in 1:10:100
+   lines!(ax, [x_wire[i], x_wire[i]], [y_wire[i], y_wire[i]], [zw[1], zw[2]], color=(:gray, 0.3))
+end
+
+axislegend(ax)
+
+f = DisplayAs.PNG(f) #hide

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,7 +40,8 @@ analytic_order = [
    "demo_tokamak_coil.jl",
    "demo_tokamak_profile.jl",
    "demo_spherical.jl",
-   "demo_x_line.jl"
+   "demo_x_line.jl",
+   "demo_zpinch.jl"
 ]
 
 applications_order = [

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -29,7 +29,8 @@ export Kappa, BiKappa, SelfSimilar, BiSelfSimilar
 export AdaptiveBoris
 export get_gyrofrequency,
        get_gyroperiod, get_gyroradius, get_velocity, get_energy,
-       energy2velocity
+       energy2velocity,
+       getB_zpinch, getB_bottle, getB_mirror, getB_tokamak_coil
 export orbit, monitor
 export TraceProblem, Cartesian, CartesianNonUniform, Spherical, SphericalNonUniformR
 

--- a/src/utility/confinement.jl
+++ b/src/utility/confinement.jl
@@ -215,3 +215,29 @@ function getB_tokamak_profile(x::AbstractFloat, y::AbstractFloat, z::AbstractFlo
 
    SA[Bx, By, Bz]
 end
+"""
+     getB_zpinch(x, y, z, I, a) -> StaticVector{Float64, 3}
+
+Get magnetic field from a Z-pinch configuration.
+Reference: [Z-pinch](https://en.wikipedia.org/wiki/Z-pinch)
+
+# Arguments
+
+  - `x,y,z::Float`: particle coordinates in [m].
+  - `I::Float`: current in the wire [A].
+  - `a::Float`: radius of the wire [m].
+"""
+function getB_zpinch(x, y, z, I, a)
+   r = hypot(x, y)
+   if r < a
+      factor = μ₀ * I / (2π * a^2)
+      Bx = -factor * y
+      By = factor * x
+   else
+      factor = μ₀ * I / (2π * r^2)
+      Bx = -factor * y
+      By = factor * x
+   end
+
+   SA[Bx, By, 0.0]
+end


### PR DESCRIPTION
- Added `getB_zpinch` function to `src/utility/confinement.jl` to calculate magnetic field for Z-pinch configuration.
- Exported `getB_zpinch` and other confinement field functions (`getB_bottle`, `getB_mirror`, `getB_tokamak_coil`) in `src/TestParticle.jl`.
- Created `docs/examples/analytic/demo_zpinch.jl` demonstrating proton tracing in a Z-pinch field.
- Registered the new demo in `docs/make.jl`.

Handles #192