### PR TITLE
doc: use callback instead of isoutofdomain

### DIFF
--- a/docs/examples/features/demo_fieldlines.jl
+++ b/docs/examples/features/demo_fieldlines.jl
@@ -47,6 +47,7 @@ solutions = Vector{ODESolution}(undef, 2 * length(seeds))
 
 ## Stop if we hit the "earth" (r < R_E)
 isoutofdomain(u, p, t) = norm(u) < TP.Rₑ
+callback = DiscreteCallback(isoutofdomain, terminate!)
 
 for (i, u0) in enumerate(seeds)
    ## Returns a vector of two ODEProblems (forward and backward)
@@ -55,12 +56,11 @@ for (i, u0) in enumerate(seeds)
    ## Solve each problem
    for (j, prob) in enumerate(probs)
       sol = solve(
-         prob, Vern9(); isoutofdomain, reltol = 1e-6, abstol = 1e-6, verbose = false)
+         prob, Vern9(); callback, reltol = 1e-6, abstol = 1e-6, verbose = false)
       solutions[2 * (i - 1) + j] = sol
    end
 end
 
-# Warnings will raise when `isoutofdomain` takes effects and returns `true`. Here they are turned off via `verbose=false`.
 #
 # ## Visualization
 #


### PR DESCRIPTION
I think in general if we just check to terminate, using `DiscreteCallback` is better (no warning and much better performance)

Ref: https://docs.sciml.ai/DiffEqDocs/stable/features/callback_functions/


```julia
julia> @b for (i, u0) in enumerate(seeds)
          ## Returns a vector of two ODEProblems (forward and backward)
          probs = trace_fieldline(u0, param, s_span; mode = :both)

          ## Solve each problem
          for (j, prob) in enumerate(probs)
             sol = solve(
                prob, Vern9(); callback, reltol = 1e-6, abstol = 1e-6, verbose = false)
             solutions[2 * (i - 1) + j] = sol
          end
       end
```

```
# Before
1.786 ms (77485 allocs: 3.056 MiB)
# With this PR
375.917 μs (13381 allocs: 537.766 KiB)
```

P.S.: This is just an example. We can ask AI to change other docs when appropriate