### PR TITLE
feat!: remove the need to specify User when q and m are specified.

### DIFF
--- a/docs/examples/applications/demo_cosmicray.jl
+++ b/docs/examples/applications/demo_cosmicray.jl
@@ -78,7 +78,7 @@ B = fill(0.0, 3, nx, ny, nz) # [B0]
 B[3, :, :, :] .= 1.0
 E(x) = SA[0.0, 0.0, 0.0] # [E₀]
 ## periodic bc = 2
-param = prepare(x, y, z, E, B; species = User, bc = 2)
+param = prepare(x, y, z, E, B; m = 1, q = 1, bc = 2)
 
 ## Initial condition
 stateinit = let

--- a/docs/examples/applications/demo_shock_drift.jl
+++ b/docs/examples/applications/demo_shock_drift.jl
@@ -94,7 +94,7 @@ sols_p = solve(ensemble_p, Vern9(), EnsembleSerial(); trajectories = 10);
 
 prob_e = let
    ## Create parameter object for Heavy Electron.
-   param_e = prepare(x, E, B; species = User, bc = 3, q = q_heavy, m = m_heavy)
+   param_e = prepare(x, E, B; bc = 3, q = q_heavy, m = m_heavy)
 
    u0_e = [x0, 0.0, 0.0, v0_p...]
    ODEProblem(trace!, u0_e, (0.0, 20.0), param_e)

--- a/docs/examples/features/demo_boris.jl
+++ b/docs/examples/features/demo_boris.jl
@@ -183,7 +183,7 @@ E_field = TP.ZeroField() # [E₀]
 
 ## If bc == 1, we set a NaN value outside the domain (default);
 ## If bc == 2, we set periodic boundary conditions.
-param = prepare(x, y, E_field, B; species = User, bc = 1)
+param = prepare(x, y, E_field, B; m = 1, q = 1, bc = 1)
 
 # Note that we set a radius of 10 - 2i, where i is the index of the particle. The trajectory domain extends from -20 to 0 in y, and -10 to 10 in x.
 # After half a cycle, the particle will move into the region where is field is not defined.

--- a/docs/examples/features/demo_dimensionless.jl
+++ b/docs/examples/features/demo_dimensionless.jl
@@ -53,7 +53,7 @@ B₀ = 10e-9            # [T]
 t₀ = 1 / Ω            # [s]
 U₀ = 1.0              # [m/s]
 l₀ = U₀ * t₀          # [m]
-E₀ = U₀*B₀            # [V/m]
+E₀ = U₀ * B₀            # [V/m]
 ## All quantities are in dimensionless units
 x = range(-10, 10, length = nx) # [l₀]
 y = range(-10, 10, length = ny) # [l₀]
@@ -63,7 +63,7 @@ B = fill(0.0, 3, nx, ny, nz) # [B₀]
 B[3, :, :, :] .= 1.0
 E = fill(0.0, 3, nx, ny, nz) # [E₀]
 
-param = prepare(x, y, z, E, B; species = User)
+param = prepare(x, y, z, E, B; m = 1, q = 1)
 
 ## Initial condition
 stateinit = let
@@ -102,7 +102,7 @@ f = DisplayAs.PNG(f) #hide
 #
 # In the small velocity scenario, it should behave similar to the non-relativistic case:
 
-param = prepare(xu -> SA[0.0, 0.0, 0.0], xu -> SA[0.0, 0.0, 1.0]; species = User)
+param = prepare(xu -> SA[0.0, 0.0, 0.0], xu -> SA[0.0, 0.0, 1.0]; m = 1, q = 1)
 tspan = (0.0, π) # half period
 stateinit = [0.0, 0.0, 0.0, 0.01, 0.0, 0.0]
 prob = ODEProblem(trace_relativistic_normalized!, stateinit, tspan, param)
@@ -124,7 +124,7 @@ f = DisplayAs.PNG(f) #hide
 
 # In the large velocity scenario, relativistic effect takes place:
 
-param = prepare(xu -> SA[0.0, 0.0, 0.0], xu -> SA[0.0, 0.0, 1.0]; species = User)
+param = prepare(xu -> SA[0.0, 0.0, 0.0], xu -> SA[0.0, 0.0, 1.0]; m = 1, q = 1)
 tspan = (0.0, π) # half period
 stateinit = [0.0, 0.0, 0.0, 0.9, 0.0, 0.0]
 prob = ODEProblem(trace_relativistic_normalized!, stateinit, tspan, param)
@@ -164,7 +164,7 @@ E_field(x) = SA[Emag_dim, 0.0, 0.0]
 x0_dim = [0.0, 0.0, 0.0] # [m]
 v0_dim = [0.0, 0.01c, 0.0] # [m/s]
 stateinit1 = [x0_dim..., v0_dim...]
-tspan1 = (0, 2π*t_dim) # [s]
+tspan1 = (0, 2π * t_dim) # [s]
 
 param1 = prepare(E_field, B_field, species = Proton)
 prob1 = ODEProblem(trace!, stateinit1, tspan1, param1)
@@ -174,7 +174,7 @@ sol1 = solve(prob1, Vern9(); reltol = 1e-4, abstol = 1e-6)
 B_normalize(x) = SA[0, 0, B_dim / B_dim]
 E_normalize(x) = SA[Emag_dim / E_dim, 0.0, 0.0]
 ## For full EM problems, the normalization of E and B should be done separately.
-param2 = prepare(E_normalize, B_normalize; species = User)
+param2 = prepare(E_normalize, B_normalize; m = 1, q = 1)
 ## Scale initial conditions by the conversion factors
 x0_norm = x0_dim ./ l_dim
 v0_norm = v0_dim ./ U_dim
@@ -219,7 +219,7 @@ B₀ = 10e-9            # [T]
 t₀ = 1 / Ω            # [s]
 U₀ = 1.0              # [m/s]
 l₀ = U₀ * t₀          # [m]
-E₀ = U₀*B₀            # [V/m]
+E₀ = U₀ * B₀            # [V/m]
 
 x = range(-10, 10, length = nx) # [l₀]
 y = range(-10, 10, length = ny) # [l₀]
@@ -231,7 +231,7 @@ E_zero(x) = SA[0.0, 0.0, 0.0] # [E₀]
 
 ## If bc == 1, we set a NaN value outside the domain (default);
 ## If bc == 2, we set periodic boundary conditions.
-param = prepare(x, y, E_zero, B; species = User, bc = 2);
+param = prepare(x, y, E_zero, B; m = 1, q = 1, bc = 2);
 
 # Note that we set a radius of 10, so the trajectory extent from -20 to 0 in y, which is beyond the original y range.
 

--- a/docs/examples/features/demo_energy_conservation.jl
+++ b/docs/examples/features/demo_energy_conservation.jl
@@ -102,7 +102,7 @@ const native_solvers = [
 
 uniform_B(x) = SA[0, 0, B₀]
 
-param1 = prepare(ZeroField(), uniform_B; species = User, q = q, m = m)
+param1 = prepare(ZeroField(), uniform_B; q = q, m = m)
 x0_1 = [0.0, 0.0, 0.0]
 v0_1 = [1.0, 0.0, 0.0]
 tspan1 = (0.0, 50.0)
@@ -127,7 +127,7 @@ f = DisplayAs.PNG(f) #hide
 
 constant_E(x, t) = SA[E₀, 0.0, 0.0]
 
-param2 = prepare(constant_E, ZeroField(); species = User, q = q, m = m)
+param2 = prepare(constant_E, ZeroField(); q = q, m = m)
 x0_2 = [0.0, 0.0, 0.0]
 v0_2 = [0.0, 0.0, 0.0] # Start from rest
 tspan2 = (0.0, 40.0)
@@ -161,7 +161,7 @@ function mirror_B(x)
    return SA[Bx, By, Bz]
 end
 
-param3 = prepare(ZeroField(), mirror_B; species = User, q = q, m = m)
+param3 = prepare(ZeroField(), mirror_B; q = q, m = m)
 x0_3 = [0.1, 0.0, 0.0]
 v0_3 = [0.5, 0.5, 1.0]
 tspan3 = (0.0, 200.0)

--- a/docs/examples/features/demo_ensemble.jl
+++ b/docs/examples/features/demo_ensemble.jl
@@ -127,7 +127,7 @@ E_func(x) = SA[0.0, 0.0, 0.0] # E is zero
 
 ## Prepare parameters
 ## bc=2 uses periodic boundary conditions
-param_custom = prepare(x_norm, y_norm, z_norm, E_func, B_norm; species = User, bc = 2)
+param_custom = prepare(x_norm, y_norm, z_norm, E_func, B_norm; m = 1, q = 1, bc = 2)
 
 ## Initial condition
 stateinit_custom = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0]

--- a/docs/examples/features/demo_phase_error.jl
+++ b/docs/examples/features/demo_phase_error.jl
@@ -36,7 +36,7 @@ t_end = n_periods * T_period
 tspan = (0.0, t_end)
 
 ## Prepare the problem parameters
-param = prepare(E_func, B_func; species = User, q = q, m = m)
+param = prepare(E_func, B_func; q = q, m = m)
 prob = TraceProblem(u0, tspan, param)
 
 ## Solvers

--- a/docs/examples/features/demo_savingcallback.jl
+++ b/docs/examples/features/demo_savingcallback.jl
@@ -58,8 +58,8 @@ z /= l₀
 B ./= B₀
 E(x) = SA[0.0 / E₀, 0.0 / E₀, 0.0 / E₀]
 
-## By default User type assumes q=1, m=1; bc=2 uses periodic boundary conditions
-param = prepare(x, y, z, E, B; species = User, bc = 2)
+## bc=2 uses periodic boundary conditions
+param = prepare(x, y, z, E, B; m = 1, q = 1, bc = 2)
 
 tspan = (0.0, π) # half averaged gyroperiod based on B₀
 

--- a/docs/examples/features/demo_unitful.jl
+++ b/docs/examples/features/demo_unitful.jl
@@ -20,6 +20,6 @@ v0 = [0.0, 0.01, 0.0] * Unitful.c0 # [m/s]
 u0 = [x0..., v0...]
 tspan = (0.0u"s", 2π * t_max) # [s]
 
-param = prepare(E_field, B_field, species = User, q = Unitful.q, m = Unitful.mp)
+param = prepare(E_field, B_field, q = Unitful.q, m = Unitful.mp)
 prob = ODEProblem(trace!, u0, tspan, param)
 solve(prob, Vern9())

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -23,7 +23,7 @@ export prepare, prepare_gc, get_gc, get_gc_func
 export trace!, trace_relativistic!, trace_normalized!, trace_relativistic_normalized!,
        trace, trace_relativistic, trace_relativistic_normalized, trace_gc!, trace_gc_1st!,
        trace_gc_drifts!, trace_gc_flr!, trace_gc_exb!, trace_fieldline!, trace_fieldline
-export Proton, Electron, Ion, User
+export Proton, Electron, Ion
 export Maxwellian, BiMaxwellian
 export Kappa, BiKappa
 export AdaptiveBoris
@@ -36,9 +36,15 @@ export orbit, monitor
 export TraceProblem, CartesianGrid, RectilinearGrid, StructuredGrid
 
 """
-Type for the particles, `Proton`, `Electron`, `Ion`, or `User`.
+Type for the particles: `Proton`, `Electron`.
 """
-@enum Species Proton Electron Ion User
+struct Species{M, Q}
+   m::M
+   q::Q
+end
+
+Ion(m, q = 1) = Species(m * mᵢ, q * qᵢ)
+Ion(; m = 1, q = 1) = Species(m * mᵢ, q * qᵢ)
 
 include("types.jl")
 include("fields/Fields.jl")

--- a/src/gc.jl
+++ b/src/gc.jl
@@ -1,10 +1,11 @@
 # Guiding center.
 
 function prepare_gc(xv, xrange::T, yrange::T, zrange::T, E::TE, B::TB;
-      species::Species = Proton, q::AbstractFloat = 1.0, m::AbstractFloat = 1.0,
+      species = Proton, q = nothing, m = nothing,
       order::Int = 1,
       bc::Int = 1, removeExB = true) where {T <: AbstractRange, TE, TB}
-   q, m = getchargemass(species, q, m)
+   q = @something q species.q
+   m = @something m species.m
    x, v = xv[SA[1:3...]], xv[SA[4:6...]]
 
    E = TE <: AbstractArray ?
@@ -18,7 +19,7 @@ function prepare_gc(xv, xrange::T, yrange::T, zrange::T, E::TE, B::TB;
    Bmag_particle = √(bparticle[1]^2 + bparticle[2]^2 + bparticle[3]^2)
    b̂particle = bparticle ./ Bmag_particle
    # vector of Larmor radius
-   ρ = (b̂particle × v) ./ (q/m*Bmag_particle)
+   ρ = (b̂particle × v) ./ (q / m * Bmag_particle)
    # Get the guiding center location
    X = x - ρ
    # Get EM field at guiding center
@@ -42,16 +43,17 @@ function prepare_gc(xv, xrange::T, yrange::T, zrange::T, E::TE, B::TB;
    stateinit_gc, (q, m, μ, Field(E), Field(B))
 end
 
-function prepare_gc(xv, E, B; species::Species = Proton, q::AbstractFloat = 1.0,
-      m::AbstractFloat = 1.0, removeExB = true)
-   q, m = getchargemass(species, q, m)
+function prepare_gc(xv, E, B; species = Proton, q = nothing,
+      m = nothing, removeExB = true)
+   q = @something q species.q
+   m = @something m species.m
    x, v = xv[SA[1:3...]], xv[SA[4:6...]]
 
    bparticle = B(x)
    Bmag_particle = √(bparticle[1]^2 + bparticle[2]^2 + bparticle[3]^2)
    b̂particle = bparticle ./ Bmag_particle
    # vector of Larmor radius
-   ρ = (b̂particle × v) ./ (q/m*Bmag_particle)
+   ρ = (b̂particle × v) ./ (q / m * Bmag_particle)
    # Get the guiding center location
    X = x - ρ
    # Get EM field at guiding center
@@ -96,7 +98,7 @@ function get_gc(xu, param)
    B = B_field(xu, t)
    B² = B[1]^2 + B[2]^2 + B[3]^2
    # vector of Larmor radius
-   ρ = B × v ./ (q2m*B²)
+   ρ = B × v ./ (q2m * B²)
 
    X = @views xu[1:3] - ρ
 end
@@ -108,7 +110,7 @@ function get_gc(x, y, z, vx, vy, vz, bx, by, bz, q2m)
 
    B² = bx^2 + by^2 + bz^2
    # vector of Larmor radius
-   ρ = B × v ./ (q2m*B²)
+   ρ = B × v ./ (q2m * B²)
 
    X = l - ρ
 end
@@ -133,7 +135,9 @@ function get_gc(
    X
 end
 
-get_gc(x, y, z, vx, vy, vz, bx, by, bz, q, m) = get_gc(x, y, z, vx, vy, vz, bx, by, bz, q/m)
+function get_gc(x, y, z, vx, vy, vz, bx, by, bz, q, m)
+   get_gc(x, y, z, vx, vy, vz, bx, by, bz, q / m)
+end
 
 """
      get_gc_func(param)

--- a/src/prepare.jl
+++ b/src/prepare.jl
@@ -67,9 +67,10 @@ function prepare_field(f::AbstractArray, x...; gridtype, order, bc, kw...)
    Field(getinterp(gridtype, f, x..., order, bc; kw...))
 end
 
-function _prepare(E, B, F, args...; species::Species = Proton, q = 1.0,
-      m = 1.0, gridtype = CartesianGrid, kw...)
-   q, m = getchargemass(species, q, m)
+function _prepare(E, B, F, args...; species = Proton, q = nothing,
+      m = nothing, gridtype = CartesianGrid, kw...)
+   q = @something q species.q
+   m = @something m species.m
    q2m = q / m
    fE = prepare_field(E, args...; gridtype, kw...)
    fB = prepare_field(B, args...; gridtype, kw...)
@@ -90,7 +91,8 @@ Return a tuple consists of particle charge-mass ratio for a prescribed `species`
 mass `m` for a prescribed `species`, analytic/interpolated EM field functions, and external force `F`.
 
 Prescribed `species` are `Electron` and `Proton`;
-other species can be manually specified with `species=Ion/User`, `q` and `m`.
+other species can be manually specified with `m` and `q` keywords or `species = Ion(m̄, q̄)`,
+where `m̄` and `q̄` are the mass and charge numbers respectively.
 
 Direct range input for uniform grid in 1/2/3D is supported.
 For 1D grid, an additional keyword `dir` is used for specifying the spatial direction, 1 -> x, 2 -> y, 3 -> z.
@@ -101,9 +103,9 @@ For `StructuredGrid` (spherical) grid, dimensions of field arrays should be `(Br
 
   - `order::Int=1`: order of interpolation in [1,2,3].
   - `bc::Int=1`: type of boundary conditions, 1 -> NaN, 2 -> periodic.
-  - `species::Species=Proton`: particle species.
-  - `q=1.0`: particle charge. Only works when `Species=User`.
-  - `m=1.0`: particle mass. Only works when `Species=User`.
+  - `species=Proton`: particle species.
+  - `q=nothing`: particle charge.
+  - `m=nothing`: particle mass.
   - `gridtype`: `CartesianGrid`, `RectilinearGrid`, `StructuredGrid`.
 """
 function prepare(grid::CartesianGrid, E, B, F = ZeroField(); order = 1, bc = 1, kw...)

--- a/src/utility/constants.jl
+++ b/src/utility/constants.jl
@@ -1,11 +1,14 @@
 # Physical constants in SI units
 const qₑ = -1.60217662e-19  # electron charge, [C]
 const mₑ = 9.10938356e-31   # electron mass, [kg]
-const qᵢ = 1.60217662e-19   # proton charge, [C]
+const qᵢ = 1.60217662e-19   # proton charge, [C]``
 const mᵢ = 1.673557546e-27  # proton mass, [kg]
 const c = 299792458.0       # speed of light, [m/s]
-const μ₀ = 4π*1e-7          # Vacuum permeability, [H/m]
-const ϵ₀ = 1/(c^2*μ₀)       # Vacuum permittivity, [F/m]
+const μ₀ = 4π * 1e-7          # Vacuum permeability, [H/m]
+const ϵ₀ = 1 / (c^2 * μ₀)       # Vacuum permittivity, [F/m]
 const kB = 1.38064852e-23   # Boltzmann constant, [m²kg/(s²K)]
 const Rₑ = 6371e3           # Earth radius, [m]
 const BMoment_Earth = [0.0, 0.0, -7.94e22] # [V*s/(A*m)]
+
+const Proton = Species(mᵢ, qᵢ)
+const Electron = Species(mₑ, qₑ)

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -43,26 +43,6 @@ include("loop.jl")
 include("confinement.jl")
 
 """
-     getchargemass(species::Species, q, m)
-
-Return charge and mass for `species`.
-For `species = Ion`, `q` and `m` are charge and mass numbers. For `species = User`, the input `q` and `m` are returned as is.
-"""
-function getchargemass(species::Species, q, m)
-   if species == Proton
-      q = qᵢ
-      m = mᵢ
-   elseif species == Electron
-      q = qₑ
-      m = mₑ
-   elseif species == Ion
-      q *= qᵢ
-      m *= mᵢ
-   end
-   q, m
-end
-
-"""
 Return uniform range from 2D/3D CartesianGrid.
 """
 function makegrid(grid::CartesianGrid)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,7 +151,7 @@ end
       stateinit = [x0..., u0...]
       tspan = (0.0, 1.0)
 
-      param = prepare(x, y, z, E, B, species = Ion, q = 1, m = 16) # O+
+      param = prepare(x, y, z, E, B, species = Ion(; q = 1, m = 16)) # O+
       @test param[2] ≈ 16 * mᵢ
 
       callback = DiscreteCallback(isoutofdomain, terminate!)
@@ -373,7 +373,7 @@ end
       x = sol[1:3, end]
       @test get_energy(sol[4:6, end]; m = mₑ, q = qₑ) / (x[1]-x0[1]+x[2]-x0[2]) ≈ 1e5
       # Tracing relativistic particle in dimensionless units
-      param = prepare(xu -> SA[0.0, 0.0, 0.0], xu -> SA[0.0, 0.0, 1.0]; species = User)
+      param = prepare(xu -> SA[0.0, 0.0, 0.0], xu -> SA[0.0, 0.0, 1.0]; m = 1, q = 1)
       tspan = (0.0, 1.0) # 1/2π period
       stateinit = [0.0, 0.0, 0.0, 0.5, 0.0, 0.0]
       prob = ODEProblem(trace_relativistic_normalized!, stateinit, tspan, param)
@@ -414,7 +414,7 @@ end
       # E shall be normalized by E₀
       E ./= E₀
 
-      param = prepare(x, y, z, E, B; species = User)
+      param = prepare(x, y, z, E, B; m = 1, q = 1)
 
       x0 = [0.0, 0.0, 0.0] # initial position [l₀]
       u0 = [1.0, 0.0, 0.0] # initial velocity [v₀]


### PR DESCRIPTION
Actually we change the export type, so it should be considered breaking. 

If so, let us just have a better interface for Ion

`Ion(m ,q) -> Species(m * mᵢ, q * qᵢ)`