### PR TITLE
Update performance demo to use log scale and mention defaults

### DIFF
--- a/docs/examples/features/demo_performance.jl
+++ b/docs/examples/features/demo_performance.jl
@@ -59,6 +59,7 @@ prob_ode = ODEProblem(trace, stateinit, tspan, param)
 # | AutoVern9 (adaptive) | `OrdinaryDiffEq` AutoVern9 with adaptive step |
 #
 # To simulate realistic applications, we save the solution at fixed intervals for all solvers.
+# For adaptive solvers, the default relative tolerance is `1e-3` and absolute tolerance is `1e-6`.
 
 """
 Helper functions to extract the median execution time and memory allocation.
@@ -112,6 +113,8 @@ ax = Axis(f[1, 1],
    ylabel = "Relative Memory (1.0 = Lowest)",
    xgridstyle = :dash,
    ygridstyle = :dash,
+   xscale = log10,
+   yscale = log10,
    xminorticksvisible = true,
    yminorticksvisible = true,
    xminorticks = IntervalsBetween(5),


### PR DESCRIPTION
- Changed the performance benchmark plot to use log10 scale for both axes in `docs/examples/features/demo_performance.jl`.
- Added a comment mentioning the default relative (1e-3) and absolute (1e-6) tolerances for adaptive solvers.
- This addresses the issue where `AutoVern9` solvers skew the linear plot due to higher execution times.