### PR TITLE
Improve number density demo structure and LaTeX formatting

### DIFF
--- a/docs/examples/features/demo_number_density.jl
+++ b/docs/examples/features/demo_number_density.jl
@@ -3,6 +3,7 @@
 # This example demonstrates how to calculate the number density of a group of particles
 # and compares it with the analytical solution for a freely expanding Maxwellian cloud.
 
+import DisplayAs #hide
 using TestParticle
 using Meshes
 using OrdinaryDiffEq
@@ -12,7 +13,6 @@ using LinearAlgebra
 using Random
 using CairoMakie
 CairoMakie.activate!(type = "png") #hide
-import DisplayAs #hide
 
 Random.seed!(1234)
 
@@ -23,24 +23,22 @@ N = 100_000
 m = 1.0
 q = 1.0
 T = 1.0
-# Thermal velocity in TestParticle (and VelocityDistributionFunctions) is vth = sqrt(2*T/m)
+# Thermal velocity: ``v_{th} = \sqrt{2 k_B T/m}``
 vth = sqrt(2 * T / m)
 t_end = 2.0
 
 # Initialize particles
-# Point source at origin
+# Point source at origin: ``\mathbf{r}_0 = \mathbf{0}``
 x0 = [SVector(0.0, 0.0, 0.0) for _ in 1:N];
 
 # Maxwellian velocity distribution
-# u0 = 0, p = n*T = 1*1 = 1 (assuming n=1 effectively for distribution shape), n=1
+# ``u_0 = 0``, ``p = n k_B T = 1`` (assuming ``n=1`` effectively for distribution shape)
 vdf = TestParticle.Maxwellian([0.0, 0.0, 0.0], T, 1.0; m = m)
 # Use the vectorized rand to get a Vector of SVectors
 v0 = rand(vdf, N);
 
-# Create TraceProblem template
-# We need to create a prob for each particle or use an ensemble.
-# TestParticle.trace usually takes one particle.
-# We will construct an EnsembleProblem.
+# Create `TraceProblem` template
+# Construct an `EnsembleProblem` to simulate multiple trajectories.
 
 prob_func(prob, i, repeat) = remake(prob, u0 = vcat(x0[i], v0[i]))
 
@@ -49,64 +47,60 @@ u0_dummy = vcat(x0[1], v0[1])
 # Zero fields
 param = prepare(TestParticle.ZeroField(), TestParticle.ZeroField(); q, m)
 tspan = (0.0, t_end)
-prob = ODEProblem(trace, u0_dummy, tspan, param)
+prob = ODEProblem(trace, u0_dummy, tspan, param);
 
 ensemble_prob = EnsembleProblem(prob; prob_func)
 
 # Solve
-# We use Tsit5 for efficiency, as free expansion is linear.
+# We use `Tsit5` for efficiency, as free expansion is linear.
 sols = solve(ensemble_prob, Tsit5(), EnsembleThreads(), trajectories = N);
 
 # ## Density Calculation
 
 # Define a grid for density calculation
-# The cloud expands to r ~ vth * t_end.
-# vth = sqrt(2) ~ 1.414. r ~ 1.414 * 2 ~ 2.8.
-# Let's cover [-6, 6] to see the tails.
+# The cloud expands to ``r \sim v_{th} t_{end}``.
+# With ``v_{th} = \sqrt{2} \approx 1.414`` and ``t_{end} = 2.0``, we have ``r \approx 2.8``.
+# We cover ``[-6, 6]`` to capture the tails.
 L = 6.0
 dims = (50, 50, 50)
 grid = CartesianGrid((-L, -L, -L), (L, L, L); dims)
 
-# Calculate density at t_end
-# The function expects a vector of solutions.
-# get_number_density returns count / volume
+# Calculate density at ``t_{end}``
+# `get_number_density` returns count / volume
 density = TestParticle.get_number_density(sols, grid, t_end);
 
-# Extract a 1D slice along x-axis (y=0, z=0 approx)
+# Extract a 1D slice along x-axis (approx. ``y=0, z=0``)
 mid_y = dims[2] ÷ 2
 mid_z = dims[3] ÷ 2
 density_x = density[:, mid_y, mid_z];
 
 # Grid coordinates for plotting
-# get_cell_centers returns ranges for each dimension
+# `get_cell_centers` returns ranges for each dimension
 grid_x, grid_y, grid_z = TestParticle.get_cell_centers(grid)
 xs_plot = collect(grid_x);
 
 # ## Analytical Solution
 
-# For a point source expanding with Maxwellian velocities:
-# The spatial distribution at time t is a Gaussian with standard deviation sigma_x = vth * t / sqrt(2).
-# Actually, let's derive carefully from the VDF.
-# f(v) = (1 / (pi * vth^2)^(3/2)) * exp(-v^2 / vth^2)
-# r = v * t => v = r / t.
-# Jacobian from v-space to r-space is |dv/dr| = 1/t^3.
-# n(r, t) = N * f(r/t) * (1/t^3)
-#         = N * (1 / (pi * vth^2)^(3/2)) * exp(-(r/t)^2 / vth^2) / t^3
-#         = N / (pi * (vth*t)^2)^(3/2) * exp(-r^2 / (vth*t)^2)
+# The analytical number density ``n(\mathbf{r}, t)`` for a collisionless gas of ``N`` particles expanding from a point source with a Maxwellian velocity distribution ``f(\mathbf{v})`` is derived as follows.
 #
-# Note: The Gaussian form is exp(-r^2 / (2*sigma^2)).
-# Here we have exp(-r^2 / (vth*t)^2).
-# So 2*sigma^2 = (vth*t)^2 => sigma = vth*t / sqrt(2).
+# The velocity distribution is:
+# ```math
+# f(\mathbf{v}) = \frac{1}{(\pi v_{th}^2)^{3/2}} \exp\left(-\frac{v^2}{v_{th}^2}\right)
+# ```
 #
-# Let sigma_param = vth * t_end. The exponential is exp(-r^2 / sigma_param^2).
+# For free expansion, the position of a particle at time ``t`` is given by ``\mathbf{r} = \mathbf{v}t``. Using the transformation of variables ``\mathbf{v} = \mathbf{r}/t``, the volume element transforms as ``d^3\mathbf{v} = t^{-3} d^3\mathbf{r}``.
+#
+# Conservation of particle number implies ``n(\mathbf{r}, t) d^3\mathbf{r} = N f(\mathbf{v}) d^3\mathbf{v}``.
+# Thus:
+# ```math
+# n(\mathbf{r}, t) = \frac{N}{t^3} f\left(\frac{\mathbf{r}}{t}\right) = \frac{N}{(\sqrt{\pi} v_{th} t)^3} \exp\left(-\frac{r^2}{(v_{th} t)^2}\right)
+# ```
 
 r2 = xs_plot .^ 2
-# We are taking a slice at y~0, z~0. So r^2 = x^2.
-# Note: The grid cells have finite volume. get_number_density returns density.
-# So we compare directly with n(x, 0, 0, t).
+# Compare with ``n(x, 0, 0, t)``.
 
 sigma_param = vth * t_end
-n_analytic = @. N / (sqrt(π) * sigma_param)^3 * exp(-r2 / sigma_param^2)
+n_analytic = @. N / (sqrt(π) * sigma_param)^3 * exp(-r2 / sigma_param^2);
 
 # ## Visualization
 


### PR DESCRIPTION
- Refactor `docs/examples/features/demo_number_density.jl` for better organization.
- Use proper LaTeX syntax for mathematical expressions (inline and display).
- Add rigorous analytical derivation for the number density of a freely expanding Maxwellian cloud.
- Suppress verbose intermediate outputs with semicolons.