### PR TITLE
doc: fail documentation build on demo errors

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -125,7 +125,7 @@ makedocs(;
       "API" => "api.md",
       "Plot Functions" => "plotfunctions.md"
    ],
-   warnonly = [:missing_docs, :cross_references, :linkcheck]
+   warnonly = [:missing_docs, :linkcheck]
 )
 
 DocumenterVitepress.deploydocs(;


### PR DESCRIPTION
Update `docs/make.jl` to change `warnonly` from `true` to a specific list of warning symbols: `[:missing_docs, :cross_references, :linkcheck]`.

This ensures that the documentation build will fail if any errors occur during the execution of demo examples (which are processed as `@example` blocks), while still allowing common warnings like missing docstrings or broken cross-references to pass without failing the build. This aligns with the requirement to catch errors in demos during CI.