### PR TITLE
Verify and document relativistic case for gyroradius

### DIFF
--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -211,7 +211,8 @@ function get_gyroradius(sol::AbstractODESolution, t)
 
    # Calculate gyroradius
    # r = V_perp / (q/m * B) = V_perp / (q2m * B)
-   #TODO: Check relativistic case
+   # For relativistic cases, `v` represents γv, so this effectively calculates
+   # r = γv_perp / (q/m * B) = γm * v_perp / (q * B), which is correct.
    return V_perp / abs(q2m * Bmag)
 end
 


### PR DESCRIPTION
Removed the TODO in `get_gyroradius` after verifying that the calculation is correct for relativistic particles. The state vector in relativistic simulations represents proper velocity (γv), which correctly yields the relativistic gyroradius r = p_perp / (qB) when divided by q/m (rest mass).