### PR TITLE
Precompile trace eqs

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -62,23 +62,24 @@
 
         # explicit trace functions
         t = 0.0
+        out6, out4, out3 = zeros(6), zeros(4), zeros(3)
         # non-relativistic
         trace(stateinit, param, t)
-        trace!(zeros(6), stateinit, param, t)
+        trace!(out6, stateinit, param, t)
         # relativistic
         trace_relativistic(stateinit, param, t)
-        trace_relativistic!(zeros(6), stateinit, param, t)
+        trace_relativistic!(out6, stateinit, param, t)
         # normalized
         trace_normalized(stateinit, param, t)
-        trace_normalized!(zeros(6), stateinit, param, t)
+        trace_normalized!(out6, stateinit, param, t)
         # relativistic normalized
         trace_relativistic_normalized(stateinit, param, t)
-        trace_relativistic_normalized!(zeros(6), stateinit, param, t)
+        trace_relativistic_normalized!(out6, stateinit, param, t)
         # guiding center
         trace_gc(stateinit_gc, param_gc, t)
-        trace_gc!(zeros(4), stateinit_gc, param_gc, t)
+        trace_gc!(out4, stateinit_gc, param_gc, t)
         # field line
         trace_fieldline(stateinit[1:3], param[4], t)
-        trace_fieldline!(zeros(3), stateinit[1:3], param[4], t)
+        trace_fieldline!(out3, stateinit[1:3], param[4], t)
     end
 end


### PR DESCRIPTION
Add trace equations to the precompilation workflow without invoking DifferentialEquations' `solve`.