### PR TITLE
Feat dynamical ODE

### DIFF
--- a/docs/examples/features/demo_energy_conservation.jl
+++ b/docs/examples/features/demo_energy_conservation.jl
@@ -34,13 +34,14 @@ const T = 2π / Ω
 function run_test(
         case_name, param, x0, v0, tspan, expected_energy_func;
         uselog = true, dt = 0.1, ymin = nothing, ymax = nothing,
-        odes = nothing, gis = nothing, natives = nothing
+        odes = nothing, gis = nothing, symplectics = nothing, natives = nothing
     )
     results = Tuple{String, Float64}[]
     u0 = [x0..., v0...]
     prob_ode = ODEProblem(trace_normalized!, u0, tspan, param)
     prob_gi = ODEProblem(trace_normalized, u0, tspan, param)
     prob_tp = TraceProblem(u0, tspan, param)
+    prob_dyn = DynamicalODEProblem(get_dv!, get_dx!, Vector(v0), Vector(x0), tspan, param)
 
     f = Figure(size = (1000, 600), fontsize = 18)
     if uselog
@@ -103,6 +104,14 @@ function run_test(
         color_idx += 1
     end
 
+    ## Run symplectic solvers
+    _symplectics = symplectics === nothing ? symplectic_solvers : symplectics
+    for (name, alg) in _symplectics
+        sol = solve(prob_dyn, alg; dt, adaptive = false)
+        plot_energy_error!(sol, name, color_idx)
+        color_idx += 1
+    end
+
     ## Run native solvers
     _natives = natives === nothing ? native_solvers : natives
     for (name, kwargs) in _natives
@@ -137,6 +146,10 @@ const ode_solvers = [
 
 const gi_solvers = [
     ("GIRK4", GIRK4()),
+]
+
+const symplectic_solvers = [
+    ("McAte2", McAte2()),
 ]
 
 const native_solvers = [
@@ -316,7 +329,8 @@ f, results = run_test(
         ("Tsit5", Tsit5()),
         ("Vern7", Vern7()),
     ],
-    gis = []
+    gis = [],
+    symplectics = [("McAte2", McAte2())]
 )
 f = DisplayAs.PNG(f) #hide
 

--- a/docs/examples/features/demo_energy_conservation.jl
+++ b/docs/examples/features/demo_energy_conservation.jl
@@ -41,7 +41,7 @@ function run_test(
     prob_ode = ODEProblem(trace_normalized!, u0, tspan, param)
     prob_gi = ODEProblem(trace_normalized, u0, tspan, param)
     prob_tp = TraceProblem(u0, tspan, param)
-    prob_dyn = DynamicalODEProblem(get_dv!, get_dx!, Vector(v0), Vector(x0), tspan, param)
+    prob_dyn = DynamicalODEProblem(get_dv!, get_dx!, v0, x0, tspan, param)
 
     f = Figure(size = (1000, 600), fontsize = 18)
     if uselog

--- a/docs/examples/features/demo_performance.jl
+++ b/docs/examples/features/demo_performance.jl
@@ -62,6 +62,7 @@ solvers = [
     ("Vern9 (adaptive)", "`OrdinaryDiffEq` Vern9 with adaptive step", :Adaptive, () -> solve(prob_ode, Vern9(); saveat = dt)),
     ("AutoVern7 (adaptive)", "`OrdinaryDiffEq` AutoVern7 with adaptive step", :Adaptive, () -> solve(prob_ode, AutoVern7(Rodas5()); saveat = dt)),
     ("AutoVern9 (adaptive)", "`OrdinaryDiffEq` AutoVern9 with adaptive step", :Adaptive, () -> solve(prob_ode, AutoVern9(Rodas5()); saveat = dt)),
+    ("ImplicitMidpoint", "`OrdinaryDiffEq` ImplicitMidpoint with fixed step", :Fixed, () -> solve(prob_ode, ImplicitMidpoint(); adaptive = false, dt, dense = false)),
     ("GIEuler", "GeometricIntegrators Euler", :GI, () -> solve(prob_gi, GIEuler(); dt)),
     ("GIMidpoint", "GeometricIntegrators Midpoint", :GI, () -> solve(prob_gi, GIMidpoint(); dt)),
     ("GIRK4", "GeometricIntegrators RK4", :GI, () -> solve(prob_gi, GIRK4(); dt)),

--- a/ext/TestParticleRecursiveArrayToolsExt.jl
+++ b/ext/TestParticleRecursiveArrayToolsExt.jl
@@ -8,13 +8,13 @@ using RecursiveArrayTools: ArrayPartition
 function trace!(du, u::ArrayPartition, p, t)
     v = u.x[2]
     du.x[1] .= v
-    du.x[2] .= get_dv(u.x[1], v, p, t)
+    du.x[2] .= get_dv(v, u.x[1], p, t)
     return nothing
 end
 
 function trace(u::ArrayPartition, p, t)
     v = u.x[2]
-    dv = get_dv(u.x[1], v, p, t)
+    dv = get_dv(v, u.x[1], p, t)
     return vcat(v, dv)
 end
 

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -30,6 +30,7 @@ import LinearAlgebra: ×
 export prepare, prepare_gc, get_gc, get_gc_func, ZeroField
 export trace!, trace_relativistic!, trace_normalized!, trace_relativistic_normalized!,
     trace, trace_relativistic, trace_normalized, trace_relativistic_normalized,
+    get_dx!, get_dv!,
     trace_gc!,
     trace_gc_drifts!, trace_gc_flr!, trace_gc_exb!,
     trace_fieldline!, trace_fieldline, TraceFieldlineProblem,

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -17,7 +17,7 @@ end
 
 In-place solver components for `DynamicalODEProblem` (location).
 """
-function get_dx!(dx, x, v, p, t)
+function get_dx!(dx, v, x, p, t)
     dx .= v
     return
 end
@@ -27,7 +27,7 @@ end
 
 In-place solver components for `DynamicalODEProblem` (velocity) with normalized EM fields.
 """
-function get_dv!(dv, x, v, p, t)
+function get_dv!(dv, v, x, p, t)
     E = get_EField(p)(x, t)
     B = get_BField(p)(x, t)
 

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -3,7 +3,7 @@
 get_x(u) = @inbounds SA[u[1], u[2], u[3]]
 get_v(u) = @inbounds SA[u[4], u[5], u[6]]
 
-function get_dv(x, v, p, t)
+function get_dv(v, x, p, t)
     q2m, m, Efunc, Bfunc, Ffunc = p
     E = Efunc(x, t)
     B = Bfunc(x, t)
@@ -13,7 +13,7 @@ function get_dv(x, v, p, t)
 end
 
 """
-    get_dx!(dx, x, v, p, t)
+    get_dx!(dx, v, x, p, t)
 
 In-place solver components for `DynamicalODEProblem` (location).
 """
@@ -23,15 +23,17 @@ function get_dx!(dx, v, x, p, t)
 end
 
 """
-    get_dv!(dv, x, v, p, t)
+    get_dv!(dv, v, x, p, t)
 
-In-place solver components for `DynamicalODEProblem` (velocity) with normalized EM fields.
+In-place solver components for `DynamicalODEProblem` (velocity).
 """
 function get_dv!(dv, v, x, p, t)
-    E = get_EField(p)(x, t)
-    B = get_BField(p)(x, t)
+    q2m, m, Efunc, Bfunc, Ffunc = p
+    E = Efunc(x, t)
+    B = Bfunc(x, t)
+    F = Ffunc(x, t)
 
-    dv .= v × B + E
+    dv .= q2m * (v × B + E) + F / m
 
     return
 end
@@ -54,7 +56,7 @@ ODE equations for charged particle moving in EM field and external force field w
 function trace!(dy, y, p, t)
     v = get_v(y)
     @inbounds dy[1:3] = v
-    @inbounds dy[4:6] = get_dv(y, v, p, t)
+    @inbounds dy[4:6] = get_dv(v, y, p, t)
 
     return
 end
@@ -66,7 +68,7 @@ ODE equations for charged particle moving in EM field and external force field w
 """
 function trace(y, p, t)
     v = y[SA[4:6...]]
-    dv = get_dv(y, v, p, t)
+    dv = get_dv(v, y, p, t)
     return vcat(v, dv)
 end
 
@@ -79,7 +81,7 @@ function trace_relativistic!(dy, y, p, t)
     γv = get_v(y)
     v = get_relativistic_v(γv)
     @inbounds dy[1:3] = v
-    @inbounds dy[4:6] = get_dv(y, v, p, t)
+    @inbounds dy[4:6] = get_dv(v, y, p, t)
 
     return
 end
@@ -150,7 +152,7 @@ ODE equations for relativistic charged particle (x, γv) moving in static EM fie
 function trace_relativistic(y, p, t)
     γv = get_v(y)
     v = get_relativistic_v(γv)
-    dv = get_dv(y, v, p, t)
+    dv = get_dv(v, y, p, t)
 
     return vcat(v, dv)
 end

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -12,6 +12,30 @@ function get_dv(x, v, p, t)
     return q2m * (v × B + E) + F / m
 end
 
+"""
+    get_dx!(dx, x, v, p, t)
+
+In-place solver components for `DynamicalODEProblem` (location).
+"""
+function get_dx!(dx, x, v, p, t)
+    dx .= v
+    return
+end
+
+"""
+    get_dv!(dv, x, v, p, t)
+
+In-place solver components for `DynamicalODEProblem` (velocity) with normalized EM fields.
+"""
+function get_dv!(dv, x, v, p, t)
+    E = get_EField(p)(x, t)
+    B = get_BField(p)(x, t)
+
+    dv .= v × B + E
+
+    return
+end
+
 function get_relativistic_v(γv; c = c)
     γ²v² = γv[1]^2 + γv[2]^2 + γv[3]^2
     if γ²v² > eps(eltype(γv))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -484,3 +484,4 @@ include("test_hybrid.jl")
 
 include("test_boris_kernel.jl")
 include("test_boundary.jl")
+include("test_symplectic.jl")

--- a/test/test_symplectic.jl
+++ b/test/test_symplectic.jl
@@ -22,7 +22,7 @@ using LinearAlgebra: norm
         prob = DynamicalODEProblem(get_dv!, get_dx!, v0, x0, tspan, param)
         # McAte2 is an explicit symplectic integrator. For this separable system,
         # it should conserve energy well with O(dt^2) error.
-        sol = solve(prob, McAte2(), dt=0.01, adaptive=false)
+        sol = solve(prob, McAte2(), dt = 0.01, adaptive = false)
 
         # Energy conservation check (Total Energy H = K + V)
         function get_H(u)
@@ -35,7 +35,7 @@ using LinearAlgebra: norm
 
         H0 = get_H(sol.u[1])
         H_final = get_H(sol.u[end])
-        @test H0 ≈ H_final rtol=1e-4
+        @test H0 ≈ H_final rtol = 1.0e-4
     end
 
     @testset "Constant B-field" begin
@@ -50,23 +50,23 @@ using LinearAlgebra: norm
         param = prepare(ZeroField(), constant_B; q, m)
 
         prob = DynamicalODEProblem(get_dv!, get_dx!, v0, x0, tspan, param)
-        
+
         # McAte2 is an explicit symplectic integrator designed for separable Hamiltonians (H = T(p) + V(q)).
         # The Lorentz force Hamiltonian H = |p-qA|^2 / 2m is non-separable when B != 0 due to the vector potential A(x).
         # Thus, explicit partitioned Runge-Kutta methods like McAte2 are not exactly symplectic for the Lorentz force
         # and may exhibit energy drift, requiring smaller dt or relaxed tolerance.
-        sol = solve(prob, McAte2(), dt=0.01, adaptive=false)
+        sol = solve(prob, McAte2(), dt = 0.01, adaptive = false)
 
         K0 = 0.5 * m * norm(v0)^2
         v_final = sol.u[end].x[1]
         K_final = 0.5 * m * norm(v_final)^2
-        @test K0 ≈ K_final rtol=0.04
+        @test K0 ≈ K_final rtol = 0.04
 
         # ImplicitMidpoint is symplectic for all Hamiltonian systems, including non-separable ones.
         u0 = [x0..., v0...]
         prob_ode = ODEProblem(trace_normalized!, u0, tspan, param)
-        sol_im = solve(prob_ode, ImplicitMidpoint(), dt=0.01, adaptive=false)
+        sol_im = solve(prob_ode, ImplicitMidpoint(), dt = 0.01, adaptive = false)
         K_im = 0.5 * m * norm(sol_im.u[end][4:6])^2
-        @test K0 ≈ K_im rtol=1e-12
+        @test K0 ≈ K_im rtol = 1.0e-12
     end
 end

--- a/test/test_symplectic.jl
+++ b/test/test_symplectic.jl
@@ -1,0 +1,72 @@
+using Test
+using TestParticle
+using OrdinaryDiffEq
+using StaticArrays
+using LinearAlgebra: norm
+
+@testset "Symplectic Solvers" begin
+    @testset "Separable E-field" begin
+        q = 1.0
+        m = 1.0
+        E_y = 1.0
+        v0 = [0.0, 1.0, 0.0]
+        x0 = [1.0, 0.0, 0.0]
+        tspan = (0.0, 1.0)
+
+        # Spatially linear E field in Y direction: E = E_y * y * y_hat
+        # H = p^2/2m - q * E_y * y^2 / 2 (Separable)
+        spatial_linear_E(x, t) = SA[0.0, E_y * x[2], 0.0]
+        param = prepare(spatial_linear_E, ZeroField(); q, m)
+
+        # get_dv! and get_dx! are exported from TestParticle
+        prob = DynamicalODEProblem(get_dv!, get_dx!, v0, x0, tspan, param)
+        # McAte2 is an explicit symplectic integrator. For this separable system,
+        # it should conserve energy well with O(dt^2) error.
+        sol = solve(prob, McAte2(), dt=0.01, adaptive=false)
+
+        # Energy conservation check (Total Energy H = K + V)
+        function get_H(u)
+            v = u.x[1]
+            x = u.x[2]
+            K = 0.5 * m * norm(v)^2
+            V = -0.5 * q * E_y * x[2]^2
+            return K + V
+        end
+
+        H0 = get_H(sol.u[1])
+        H_final = get_H(sol.u[end])
+        @test H0 ≈ H_final rtol=1e-4
+    end
+
+    @testset "Constant B-field" begin
+        q = 1.0
+        m = 1.0
+        B_z = 1.0
+        v0 = [1.0, 0.0, 0.0]
+        x0 = [0.0, 0.0, 0.0]
+        tspan = (0.0, 2π)
+
+        constant_B(x, t) = SA[0.0, 0.0, B_z]
+        param = prepare(ZeroField(), constant_B; q, m)
+
+        prob = DynamicalODEProblem(get_dv!, get_dx!, v0, x0, tspan, param)
+        
+        # McAte2 is an explicit symplectic integrator designed for separable Hamiltonians (H = T(p) + V(q)).
+        # The Lorentz force Hamiltonian H = |p-qA|^2 / 2m is non-separable when B != 0 due to the vector potential A(x).
+        # Thus, explicit partitioned Runge-Kutta methods like McAte2 are not exactly symplectic for the Lorentz force
+        # and may exhibit energy drift, requiring smaller dt or relaxed tolerance.
+        sol = solve(prob, McAte2(), dt=0.01, adaptive=false)
+
+        K0 = 0.5 * m * norm(v0)^2
+        v_final = sol.u[end].x[1]
+        K_final = 0.5 * m * norm(v_final)^2
+        @test K0 ≈ K_final rtol=0.04
+
+        # ImplicitMidpoint is symplectic for all Hamiltonian systems, including non-separable ones.
+        u0 = [x0..., v0...]
+        prob_ode = ODEProblem(trace_normalized!, u0, tspan, param)
+        sol_im = solve(prob_ode, ImplicitMidpoint(), dt=0.01, adaptive=false)
+        K_im = 0.5 * m * norm(sol_im.u[end][4:6])^2
+        @test K0 ≈ K_im rtol=1e-12
+    end
+end


### PR DESCRIPTION
Explore and explain why symplectic integrators implemented for the Hamiltonian system fail for the Lorentz system.
Add `ImplicitMidPoint()` to demo and test.