### PR TITLE
refactor: combine Boris, MultistepBoris, AdaptiveBoris types

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -151,29 +151,29 @@ SUITE["trace"]["numerical field"]["out of place"] = @benchmarkable solve(
     $prob_oop_num, Tsit5(); save_idxs = [1, 2, 3]
 )
 SUITE["trace"]["numerical field"]["Boris"] = @benchmarkable TP.solve(
-    $prob_boris; dt = 1 / 7, savestepinterval = 10
+    $prob_boris, Boris(); dt = 1 / 7, savestepinterval = 10
 )
 SUITE["trace"]["numerical field"]["Boris with fields"] = @benchmarkable TP.solve(
-    $prob_boris; dt = 1 / 7, savestepinterval = 10, save_fields = true
+    $prob_boris, Boris(); dt = 1 / 7, savestepinterval = 10, save_fields = true
 )
 SUITE["trace"]["numerical field"]["Boris ensemble"] = @benchmarkable TP.solve(
-    $prob_boris; dt = 1 / 7, savestepinterval = 10, trajectories = 2
+    $prob_boris, Boris(); dt = 1 / 7, savestepinterval = 10, trajectories = 2
 )
 SUITE["trace"]["numerical field"]["Multistep Boris"] = @benchmarkable TP.solve(
-    $prob_boris; dt = 1 / 7, savestepinterval = 10, n = 2
+    $prob_boris, MultistepBoris2(; n = 2); dt = 1 / 7, savestepinterval = 10
 )
 SUITE["trace"]["numerical field"]["Hyper Boris (n=2, N=4)"] = @benchmarkable TP.solve(
-    $prob_boris; dt = 1 / 7, savestepinterval = 10, n = 2, N = 4
+    $prob_boris, MultistepBoris4(; n = 2); dt = 1 / 7, savestepinterval = 10
 )
 SUITE["trace"]["numerical field"]["Hyper Boris (n=2, N=6)"] = @benchmarkable TP.solve(
-    $prob_boris; dt = 1 / 7, savestepinterval = 10, n = 2, N = 6
+    $prob_boris, MultistepBoris6(; n = 2); dt = 1 / 7, savestepinterval = 10
 )
 alg_adaptive = AdaptiveBoris(safety = 0.1)
 SUITE["trace"]["numerical field"]["Adaptive Boris"] = @benchmarkable TP.solve(
     $prob_boris, $alg_adaptive
 )
 SUITE["trace"]["numerical field"]["Boris kernel"] = @benchmarkable TP.solve(
-    $prob_boris, CPU(); dt = 1 / 7, savestepinterval = 10
+    $prob_boris, Boris(), CPU(); dt = 1 / 7, savestepinterval = 10
 )
 
 # Time-Dependent Field

--- a/docs/examples/analytic/demo_proton_dipole.jl
+++ b/docs/examples/analytic/demo_proton_dipole.jl
@@ -145,7 +145,7 @@ push!(results, ("Vern9 with StepsizeLimiter", get_energy_ratio(sol)));
 
 dt = 1.0e-4
 prob_boris = TraceProblem(stateinit, tspan, param)
-sol_boris = TestParticle.solve(prob_boris; dt)[1]
+sol_boris = TestParticle.solve(prob_boris, Boris(); dt)[1]
 push!(results, ("Boris method, dt=1e-4", get_energy_ratio(sol_boris)));
 
 # Comparison of energy conservation:

--- a/docs/examples/applications/demo_fermi_foreshock.jl
+++ b/docs/examples/applications/demo_fermi_foreshock.jl
@@ -297,7 +297,7 @@ end
 dt = 2.0e-4 # [s]
 param = prepare(E, Bcase2; species = Electron);
 prob = TraceProblem(stateinit, tspan, param; prob_func)
-sols = TP.solve(prob; dt, trajectories, isoutside, savestepinterval = 100);
+sols = TP.solve(prob, Boris(); dt, trajectories, isoutside, savestepinterval = 100);
 
 ## maximum acceleration ratio particle index
 imax = find_max_acceleration_index(sols)

--- a/docs/examples/applications/demo_shock_phase_space.jl
+++ b/docs/examples/applications/demo_shock_phase_space.jl
@@ -231,7 +231,7 @@ function prob_func_m2(prob, i, repeat)
 end
 
 prob_m2 = TraceProblem(SA[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], tspan, param; prob_func = prob_func_m2)
-@time sols_m2 = TP.solve(prob_m2; dt, savestepinterval = 10, trajectories = nparticles_m2);
+@time sols_m2 = TP.solve(prob_m2, Boris(); dt, savestepinterval = 10, trajectories = nparticles_m2);
 
 hists_up_m2 = reconstruct_liouville_projections(
     sols_m2, detector_up, vdf, n_up, Vsphere_m2
@@ -278,7 +278,7 @@ function reconstruct_backward_projections(
     )
 
     sols_bw = TP.solve(
-        prob_bw, EnsembleThreads(); dt = -dt, trajectories = nparticles_bw,
+        prob_bw, Boris(), EnsembleThreads(); dt = -dt, trajectories = nparticles_bw,
         savestepinterval = 10, isoutside = (u, p, t) -> u[1] > x_source[1] + 50.0e3
     )
 

--- a/docs/examples/applications/demo_shock_phase_space.jl
+++ b/docs/examples/applications/demo_shock_phase_space.jl
@@ -105,7 +105,7 @@ u0_dummy = SA[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 prob = TraceProblem(u0_dummy, tspan, param; prob_func = prob_func_maxwellian)
 
 println("Starting simulation with $nparticles particles...")
-@time sols = TP.solve(prob; dt, savestepinterval = 10, trajectories = nparticles);
+@time sols = TP.solve(prob, Boris(); dt, savestepinterval = 10, trajectories = nparticles);
 println("Simulation complete.")
 
 ## Detector planes (upstream and downstream of the shock)

--- a/docs/examples/features/demo_accuracy.jl
+++ b/docs/examples/features/demo_accuracy.jl
@@ -26,13 +26,13 @@ CairoMakie.activate!(type = "png") #hide
 # ## Solvers to Test
 # We define a set of Boris solvers and ODE solvers to compare.
 boris_solvers = [
-    ("Standard Boris", Dict(:n => 1, :N => 2)),
-    ("Multicycle Boris (n=2)", Dict(:n => 2, :N => 2)),
-    ("Multicycle Boris (n=4)", Dict(:n => 4, :N => 2)),
-    ("Hyper Boris (n=1, N=6)", Dict(:n => 1, :N => 6)),
-    ("Hyper Boris (n=2, N=6)", Dict(:n => 2, :N => 6)),
-    ("Hyper Boris (n=4, N=4)", Dict(:n => 4, :N => 4)),
-    ("Hyper Boris (n=4, N=6)", Dict(:n => 4, :N => 6)),
+    ("Standard Boris", Boris()),
+    ("Multicycle Boris (n=2)", MultistepBoris2(; n = 2)),
+    ("Multicycle Boris (n=4)", MultistepBoris2(; n = 4)),
+    ("Hyper Boris (n=1, N=6)", MultistepBoris6(; n = 1)),
+    ("Hyper Boris (n=2, N=6)", MultistepBoris6(; n = 2)),
+    ("Hyper Boris (n=4, N=4)", MultistepBoris4(; n = 4)),
+    ("Hyper Boris (n=4, N=6)", MultistepBoris6(; n = 4)),
 ]
 
 ode_solvers = [
@@ -101,8 +101,8 @@ results1 = Dict(name => Float64[] for (name, _) in [boris_solvers; ode_solvers])
 prob1_ode = ODEProblem(trace!, u0, tspan, param)
 
 for dt in dts1
-    for (name, kwargs) in boris_solvers
-        sol = TestParticle.solve(prob1; dt, kwargs...)[1]
+    for (name, alg) in boris_solvers
+        sol = TestParticle.solve(prob1, alg; dt)[1]
         vx, vy = sol.u[end][4], sol.u[end][5]
         t_final = sol.t[end]
 
@@ -173,8 +173,8 @@ results2 = Dict(name => Float64[] for (name, _) in [boris_solvers; ode_solvers])
 prob2_ode = ODEProblem(trace!, u0, tspan2, param2)
 
 for dt in dts2
-    for (name, kwargs) in boris_solvers
-        sol = TestParticle.solve(prob2; dt, kwargs...)[1]
+    for (name, alg) in boris_solvers
+        sol = TestParticle.solve(prob2, alg; dt)[1]
 
         max_err = 0.0
         for i in eachindex(sol.u)
@@ -286,9 +286,9 @@ end
 # Each row compares a specific solver against the analytical solution at both timesteps.
 
 drift_solvers_all = [
-    ("Standard Boris", :boris, Dict(:n => 1, :N => 2)),
+    ("Standard Boris", :boris, Boris()),
     ("RK4", :ode, RK4()),
-    ("Hyper Boris (n=4, N=6)", :boris, Dict(:n => 4, :N => 6)),
+    ("Hyper Boris (n=4, N=6)", :boris, MultistepBoris6(; n = 4)),
     ("Tsit5", :ode, Tsit5()),
     ("Vern6", :ode, Vern6()),
 ]
@@ -339,7 +339,7 @@ for (row, (name, type, config)) in enumerate(drift_solvers_all)
 
         ## Plot solver result
         if type == :boris
-            sol = TestParticle.solve(prob3; dt, config...)[1]
+            sol = TestParticle.solve(prob3, config; dt)[1]
             t_eval = range(0.0, t_end3, step = dt)
             x_drifts = [sol(t)[1] - vD_magnitude * t for t in t_eval]
             scatterlines!(

--- a/docs/examples/features/demo_boris.jl
+++ b/docs/examples/features/demo_boris.jl
@@ -94,10 +94,10 @@ dt = tperiod / 4
 
 prob = TraceProblem(stateinit, tspan, param)
 
-sol_boris = TP.solve(prob; dt)[1];
-sol_boris_2 = TP.solve(prob; dt, n = 2)[1];
-sol_boris_4 = TP.solve(prob; dt, n = 4)[1];
-sol_boris_hyper = TP.solve(prob; dt, n = 2, N = 4)[1];
+sol_boris = TP.solve(prob, Boris(); dt)[1];
+sol_boris_2 = TP.solve(prob, MultistepBoris2(; n = 2); dt)[1];
+sol_boris_4 = TP.solve(prob, MultistepBoris2(; n = 4); dt)[1];
+sol_boris_hyper = TP.solve(prob, MultistepBoris4(; n = 2); dt)[1];
 
 alg_adaptive = AdaptiveBoris(safety = 0.1)
 sol_boris_adaptive = TP.solve(prob, alg_adaptive)[1];
@@ -120,10 +120,10 @@ dt = tperiod / 8
 
 prob = TraceProblem(stateinit, tspan, param)
 
-sol_boris = TP.solve(prob; dt)[1];
-sol_boris_2 = TP.solve(prob; dt, n = 2)[1];
-sol_boris_4 = TP.solve(prob; dt, n = 4)[1];
-sol_boris_hyper = TP.solve(prob; dt, n = 2, N = 4)[1];
+sol_boris = TP.solve(prob, Boris(); dt)[1];
+sol_boris_2 = TP.solve(prob, MultistepBoris2(; n = 2); dt)[1];
+sol_boris_4 = TP.solve(prob, MultistepBoris2(; n = 4); dt)[1];
+sol_boris_hyper = TP.solve(prob, MultistepBoris4(; n = 2); dt)[1];
 
 prob = ODEProblem(trace!, stateinit, tspan, param)
 sol1 = solve(prob, Tsit5(); adaptive = false, dt, dense = false, saveat = dt);
@@ -142,10 +142,10 @@ dt = tperiod / 12
 prob_boris = TraceProblem(stateinit, tspan, param)
 prob = ODEProblem(trace!, stateinit, tspan, param)
 
-sol_boris = TP.solve(prob_boris; dt, savestepinterval = 36)[1];
-sol_boris_2 = TP.solve(prob_boris; dt, savestepinterval = 36, n = 2)[1];
-sol_boris_4 = TP.solve(prob_boris; dt, savestepinterval = 36, n = 4)[1];
-sol_boris_hyper = TP.solve(prob_boris; dt, savestepinterval = 36, n = 2, N = 4)[1];
+sol_boris = TP.solve(prob_boris, Boris(); dt, savestepinterval = 36)[1];
+sol_boris_2 = TP.solve(prob_boris, MultistepBoris2(; n = 2); dt, savestepinterval = 36)[1];
+sol_boris_4 = TP.solve(prob_boris, MultistepBoris2(; n = 4); dt, savestepinterval = 36)[1];
+sol_boris_hyper = TP.solve(prob_boris, MultistepBoris4(; n = 2); dt, savestepinterval = 36)[1];
 sol_boris_adaptive = TP.solve(
     prob_boris,
     AdaptiveBoris(safety = 0.1)
@@ -241,7 +241,7 @@ savestepinterval = 1
 trajectories = 2
 prob = TraceProblem(stateinit, tspan, param; prob_func)
 
-sols = TP.solve(prob; dt, savestepinterval, isoutside, trajectories)
+sols = TP.solve(prob, Boris(); dt, savestepinterval, isoutside, trajectories)
 
 f = Figure(fontsize = 18)
 ax = Axis(

--- a/docs/examples/features/demo_energy_conservation.jl
+++ b/docs/examples/features/demo_energy_conservation.jl
@@ -114,8 +114,8 @@ function run_test(
 
     ## Run native solvers
     _natives = natives === nothing ? native_solvers : natives
-    for (name, kwargs) in _natives
-        sol = TestParticle.solve(prob_tp; dt, kwargs...)[1]
+    for (name, alg) in _natives
+        sol = TestParticle.solve(prob_tp, alg; dt)[1]
         plot_energy_error!(sol, name, color_idx)
         color_idx += 1
     end
@@ -153,9 +153,9 @@ const symplectic_solvers = [
 ]
 
 const native_solvers = [
-    ("Boris", Dict{Symbol, Any}()),
-    ("Boris Multistep (n=2)", Dict{Symbol, Any}(:n => 2)),
-    ("Hyper Boris (n=2, N=4)", Dict{Symbol, Any}(:n => 2, :N => 4)),
+    ("Boris", Boris()),
+    ("Boris Multistep (n=2)", MultistepBoris2(; n = 2)),
+    ("Hyper Boris (n=2, N=4)", MultistepBoris4(; n = 2)),
 ];
 
 # ## Case 1: Constant B, Zero E

--- a/docs/examples/features/demo_ensemble.jl
+++ b/docs/examples/features/demo_ensemble.jl
@@ -206,7 +206,7 @@ savestepinterval = 1
 
 ## Reuse the basic problem parameters
 prob_boris = TraceProblem(stateinit, tspan, param; prob_func = prob_func_basic)
-trajs_boris = TestParticle.solve(prob_boris; dt, trajectories = 3, savestepinterval)
+trajs_boris = TestParticle.solve(prob_boris, Boris(); dt, trajectories = 3, savestepinterval)
 
 ## Visualization
 f = Figure(fontsize = 18)
@@ -238,7 +238,7 @@ f = DisplayAs.PNG(f) #hide
 # ### 1. Multi-threading (usually the most convenient for local runs)
 #
 # ```julia
-# sols_threads = solve(prob_boris, EnsembleThreads(); dt, trajectories, savestepinterval)
+# sols_threads = solve(prob_boris, Boris(), EnsembleThreads(); dt, trajectories, savestepinterval)
 # ```
 #
 # ### 2. Distributed (Multi-processing)
@@ -249,7 +249,7 @@ f = DisplayAs.PNG(f) #hide
 # using Distributed
 # addprocs()
 # @everywhere using TestParticle
-# sols_dist = solve(prob_boris, EnsembleDistributed(); dt, trajectories, savestepinterval)
+# sols_dist = solve(prob_boris, Boris(), EnsembleDistributed(); dt, trajectories, savestepinterval)
 # ```
 #
 # ### 3. Split-Threads (Hybrid Distributed + Multi-threading)
@@ -260,5 +260,5 @@ f = DisplayAs.PNG(f) #hide
 # using Distributed
 # addprocs()
 # @everywhere using TestParticle
-# sols_split = solve(prob_boris, EnsembleSplitThreads(); dt, trajectories, savestepinterval)
+# sols_split = solve(prob_boris, Boris(), EnsembleSplitThreads(); dt, trajectories, savestepinterval)
 # ```

--- a/docs/examples/features/demo_extrasaving.jl
+++ b/docs/examples/features/demo_extrasaving.jl
@@ -120,7 +120,7 @@ tspan_boris = (0.0, 2π)
 prob_boris = TraceProblem(u0_boris, tspan_boris, param_boris)
 
 ## Solve with field saving enabled
-sol_fields = TestParticle.solve(prob_boris; dt = 0.1, save_fields = true)[1];
+sol_fields = TestParticle.solve(prob_boris, Boris(); dt = 0.1, save_fields = true)[1];
 
 # The solution now contains 12 values per time step (6 for state + 6 for fields)
 ## Access the magnetic field along the trajectory
@@ -131,7 +131,7 @@ println("First saved B field: ", B_trajectory[1])
 println("Last saved B field: ", B_trajectory[end])
 
 ## Solve with work saving enabled
-sol_work = TestParticle.solve(prob_boris; dt = 0.1, save_work = true)[1];
+sol_work = TestParticle.solve(prob_boris, Boris(); dt = 0.1, save_work = true)[1];
 
 # The solution now contains 10 values per time step (6 for state + 4 for work rates)
 # We access the work rates along the trajectory and show at selected time steps:
@@ -163,7 +163,7 @@ println("="^70) #hide
 # Note: This requires the problem parameters (fields) to be accessible from the solution object.
 
 ## Solving without saving extra data
-sol = TestParticle.solve(prob_boris; dt = 0.1)[1];
+sol = TestParticle.solve(prob_boris, Boris(); dt = 0.1)[1];
 
 ## Compute fields and work post-simulation
 E_post, B_post = get_fields(sol);

--- a/docs/examples/features/demo_performance.jl
+++ b/docs/examples/features/demo_performance.jl
@@ -48,12 +48,12 @@ prob_gi = ODEProblem(trace, Vector(stateinit), tspan, param)
 # We benchmark the following solvers:
 
 solvers = [
-    ("Boris (n=1, N=2)", "standard Boris (n=1, N=2)", :Boris, () -> TP.solve(prob_boris; dt, n = 1, N = 2)),
-    ("Boris (n=2, N=2)", "2-cycled (n=2, N=2)", :Boris, () -> TP.solve(prob_boris; dt, n = 2, N = 2)),
-    ("Boris (n=4, N=2)", "4-cycled (n=4, N=2)", :Boris, () -> TP.solve(prob_boris; dt, n = 4, N = 2)),
-    ("Boris (n=1, N=6)", "6-th order Boris (n=1, N=6)", :Boris, () -> TP.solve(prob_boris; dt, n = 1, N = 6)),
-    ("Boris (n=2, N=6)", "Hyper Boris (n=2, N=6)", :Boris, () -> TP.solve(prob_boris; dt, n = 2, N = 6)),
-    ("Boris (n=4, N=6)", "Hyper Boris (n=4, N=6)", :Boris, () -> TP.solve(prob_boris; dt, n = 4, N = 6)),
+    ("Boris (n=1, N=2)", "standard Boris (n=1, N=2)", :Boris, () -> TP.solve(prob_boris, Boris(); dt)),
+    ("Boris (n=2, N=2)", "2-cycled (n=2, N=2)", :Boris, () -> TP.solve(prob_boris, MultistepBoris2(; n = 2); dt)),
+    ("Boris (n=4, N=2)", "4-cycled (n=4, N=2)", :Boris, () -> TP.solve(prob_boris, MultistepBoris2(; n = 4); dt)),
+    ("Boris (n=1, N=6)", "6-th order Boris (n=1, N=6)", :Boris, () -> TP.solve(prob_boris, MultistepBoris6(; n = 1); dt)),
+    ("Boris (n=2, N=6)", "Hyper Boris (n=2, N=6)", :Boris, () -> TP.solve(prob_boris, MultistepBoris6(; n = 2); dt)),
+    ("Boris (n=4, N=6)", "Hyper Boris (n=4, N=6)", :Boris, () -> TP.solve(prob_boris, MultistepBoris6(; n = 4); dt)),
     ("Tsit5 (fixed)", "`OrdinaryDiffEq` Tsit5 with fixed step", :Fixed, () -> solve(prob_ode, Tsit5(); adaptive = false, dt, dense = false)),
     ("Tsit5 (adaptive)", "`OrdinaryDiffEq` Tsit5 with adaptive step", :Adaptive, () -> solve(prob_ode, Tsit5(); saveat = dt)),
     ("Vern7 (fixed)", "`OrdinaryDiffEq` Vern7 with fixed step", :Fixed, () -> solve(prob_ode, Vern7(); adaptive = false, dt, dense = false)),

--- a/src/TestParticle.jl
+++ b/src/TestParticle.jl
@@ -37,7 +37,9 @@ export trace!, trace_relativistic!, trace_normalized!, trace_relativistic_normal
     get_gc_velocity, full_to_gc, gc_to_full
 export Proton, Electron, Ion
 export Maxwellian, BiMaxwellian, Kappa, BiKappa
-export AdaptiveBoris, AdaptiveHybrid
+export AdaptiveBoris, AdaptiveHybrid,
+    Boris, MultistepBoris,
+    MultistepBoris2, MultistepBoris4, MultistepBoris6
 export get_gyrofrequency,
     get_gyroperiod, get_gyroradius, get_velocity, get_energy, get_mean_magnitude,
     energy2velocity, get_curvature_radius, get_adiabaticity,

--- a/src/adaptive_boris.jl
+++ b/src/adaptive_boris.jl
@@ -1,6 +1,6 @@
 # Adaptive Boris method
 
-struct AdaptiveBoris{T}
+struct AdaptiveBoris{T} <: AbstractBoris
     safety::T
 end
 
@@ -14,6 +14,7 @@ function AdaptiveBoris(; safety = 0.1)
     T = typeof(safety)
     return AdaptiveBoris{T}(T(safety))
 end
+
 """
     solve(prob::TraceProblem, alg::AdaptiveBoris,
         ensemblealg::BasicEnsembleAlgorithm=EnsembleSerial();

--- a/src/adaptive_boris.jl
+++ b/src/adaptive_boris.jl
@@ -1,7 +1,7 @@
 # Adaptive Boris method
 
-struct AdaptiveBoris{T} <: AbstractBoris
-    safety::T
+struct AdaptiveBoris <: AbstractBoris
+    safety::Float64
 end
 
 """
@@ -11,8 +11,7 @@ Adaptive Boris method with adaptive time stepping based on local gyroperiod.
 The time step is determined by `dt = safety * T_gyro = safety * 2π / |qB/m|`.
 """
 function AdaptiveBoris(; safety = 0.1)
-    T = typeof(safety)
-    return AdaptiveBoris{T}(T(safety))
+    return AdaptiveBoris(Float64(safety))
 end
 
 """
@@ -176,7 +175,7 @@ end
 
 
 @muladd function _adaptive_boris!(
-        sols, prob, irange, alg, savestepinterval, isoutside,
+        sols, prob, irange, alg::AdaptiveBoris, savestepinterval, isoutside,
         save_start, save_end, save_everystep, ::Val{SaveFields}, ::Val{SaveWork}
     ) where {SaveFields, SaveWork}
     (; tspan, p, u0) = prob

--- a/src/boris.jl
+++ b/src/boris.jl
@@ -213,7 +213,7 @@ function _dispatch_boris!(
     ) where {N, SaveFields, SaveWork, F}
     return _multistep_boris!(
         sols, prob, irange, savestepinterval, dt, nt,
-        nout, isoutside, alg.n, N,
+        nout, isoutside, alg.n, Val(N),
         save_start, save_end, save_everystep,
         Val(SaveFields), Val(SaveWork)
     )
@@ -628,14 +628,16 @@ Apply Boris method for particles with index in `irange`.
 end
 
 """
-    update_velocity_multistep(v, r, dt, t, n, N, param)
+    update_velocity_multistep(v, r, dt, t, n, ::Val{N}, param)
 
 Update velocity using the Multistep/Hyper Boris method, returning the new velocity as an SVector.
 `n` specifies the number of subcycles.
 `N` specifies the gyrophase correction order. When N=2, it corresponds to the Multicycle solver. When N=4 or N=6, it is the Hyper Boris solver.
 Reference: [Zenitani & Kato 2025](https://arxiv.org/abs/2505.02270)
 """
-@muladd function update_velocity_multistep(v, r, dt, t, n::Int, N::Int, param)
+@muladd function update_velocity_multistep(
+        v, r, dt, t, n::Int, ::Val{N}, param
+    ) where {N}
     q2m, _, Efunc, Bfunc, _ = param
     E = Efunc(r, t)
     B = Bfunc(r, t)
@@ -714,11 +716,13 @@ end
 
 @inline @muladd function _multistep_boris!(
         sols, prob::TraceProblem, irange, savestepinterval, dt, nt, nout, isoutside::F,
-        n_steps::Int, N_order::Int, save_start, save_end, save_everystep, ::Val{SaveFields}, ::Val{SaveWork}
-    ) where {SaveFields, SaveWork, F}
+        n_steps::Int, ::Val{N_order}, save_start, save_end, save_everystep, ::Val{SaveFields}, ::Val{SaveWork}
+    ) where {N_order, SaveFields, SaveWork, F}
 
     velocity_updater = (v, r, dt, t, p) ->
-    update_velocity_multistep(v, r, dt, t, n_steps, N_order, p)
+    update_velocity_multistep(
+        v, r, dt, t, n_steps, Val(N_order), p
+    )
 
     _generic_boris!(
         sols, prob, irange, savestepinterval, dt, nt, nout, isoutside,

--- a/src/boris.jl
+++ b/src/boris.jl
@@ -1,5 +1,35 @@
 # Native particle pusher
 
+struct Boris <: AbstractBoris end
+
+"""
+    MultistepBoris{N}(; n=1)
+
+The Multistep/Hyper Boris method of order `N`.
+`n` specifies the number of subcycles.
+`N` specifies the gyrophase correction order:
+2 (standard), 4, or 6 (Hyper-Boris).
+"""
+struct MultistepBoris{N, T} <: AbstractBoris
+    n::T
+end
+
+@inline function MultistepBoris{N}(; n::Int = 1) where {N}
+    if N ∉ (2, 4, 6)
+        throw(
+            ArgumentError(
+                "Multistep Boris order N must be 2, 4, or 6."
+            )
+        )
+    end
+    return MultistepBoris{N, Int}(n)
+end
+
+const MultistepBoris2 = MultistepBoris{2}
+const MultistepBoris4 = MultistepBoris{4}
+const MultistepBoris6 = MultistepBoris{6}
+
+
 struct TraceProblem{uType, tType, isinplace, P, F <: AbstractODEFunction, PF} <:
     AbstractODEProblem{uType, tType, isinplace}
     f::F
@@ -108,102 +138,166 @@ In-place cross product.
 end
 
 """
-    solve(prob::TraceProblem; trajectories::Int=1, dt::AbstractFloat,
-        savestepinterval::Int=1, isoutside::Function=ODE_DEFAULT_ISOUTOFDOMAIN,
-        n::Int=1, save_start::Bool=true, save_end::Bool=true, save_everystep::Bool=true,
-        save_fields::Bool=false, save_work::Bool=false)
+    solve(prob::TraceProblem, alg::Boris,
+        ensemblealg=EnsembleSerial(); dt, kwargs...)
 
-Trace particles using the Boris method with specified `prob`.
+Trace particles using the standard Boris method.
 
-# keywords
-
-  - `trajectories::Int`: number of trajectories to trace.
+# Keywords
+  - `trajectories::Int=1`: number of trajectories.
   - `dt::AbstractFloat`: time step.
-  - `savestepinterval::Int`: saving output interval.
-  - `isoutside::Function`: pinpointing impact or checking boundaries.
-  - `n::Int=1`: number of substeps for the Multistep Boris method. 1 is standard Boris.
-  - `N::Int=2`: order of the Hyper Boris gyrophase correction (2, 4, or 6). 2 is uncorrected.
-  - `save_start::Bool=true`: save the initial condition.
-  - `save_end::Bool=true`: save the final condition.
-  - `save_everystep::Bool=true`: save the state at every `savestepinterval`.
-  - `save_fields::Bool=false`: save the electric and magnetic fields.
-  - `save_work::Bool=false`: save the work done by the electric field.
-  - `batch_size::Int=max(1, trajectories ÷ nworkers())`: the number of trajectories to process per worker in `EnsembleDistributed` and `EnsembleSplitThreads`.
-
+  - `savestepinterval::Int=1`: saving output interval.
+  - `isoutside`: boundary check function.
+  - `save_start::Bool=true`: save initial condition.
+  - `save_end::Bool=true`: save final condition.
+  - `save_everystep::Bool=true`: save at intervals.
+  - `save_fields::Bool=false`: save E and B fields.
+  - `save_work::Bool=false`: save work rates.
+  - `maxiters::Int=1_000_000`: maximum iterations.
 """
 @inline function solve(
-        prob::TraceProblem, ensemblealg::EA = EnsembleSerial();
-        trajectories::Int = 1, savestepinterval::Int = 1, dt::AbstractFloat,
-        isoutside::F = ODE_DEFAULT_ISOUTOFDOMAIN, n::Int = 1, N::Int = 2,
-        save_start::Bool = true, save_end::Bool = true, save_everystep::Bool = true,
-        save_fields::Bool = false, save_work::Bool = false, maxiters::Int = 1_000_000,
-        batch_size::Int = (ensemblealg isa EnsembleDistributed || ensemblealg isa EnsembleSplitThreads) ?
-            max(1, trajectories ÷ nworkers()) : 1
+        prob::TraceProblem, alg::Boris,
+        ensemblealg::EA = EnsembleSerial();
+        trajectories::Int = 1,
+        savestepinterval::Int = 1,
+        dt::AbstractFloat,
+        isoutside::F = ODE_DEFAULT_ISOUTOFDOMAIN,
+        save_start::Bool = true,
+        save_end::Bool = true,
+        save_everystep::Bool = true,
+        save_fields::Bool = false,
+        save_work::Bool = false,
+        maxiters::Int = 1_000_000,
+        batch_size::Int = _default_batch_size(
+            ensemblealg, trajectories
+        ),
     ) where {EA <: BasicEnsembleAlgorithm, F}
-
-    if N ∉ (2, 4, 6)
-        throw(ArgumentError("N must be 2, 4, or 6"))
-    end
-
     return _solve(
-        ensemblealg, prob, trajectories, dt, savestepinterval, isoutside, n, N,
-        save_start, save_end, save_everystep, Val(save_fields), Val(save_work), maxiters,
-        batch_size
+        ensemblealg, prob, alg, trajectories, dt,
+        savestepinterval, isoutside,
+        save_start, save_end, save_everystep,
+        Val(save_fields), Val(save_work),
+        maxiters, batch_size
+    )
+end
+
+"""
+    solve(prob::TraceProblem, alg::MultistepBoris{N},
+        ensemblealg=EnsembleSerial(); dt, kwargs...)
+
+Trace particles using the Multistep/Hyper Boris method.
+"""
+@inline function solve(
+        prob::TraceProblem, alg::MultistepBoris{N},
+        ensemblealg::EA = EnsembleSerial();
+        trajectories::Int = 1,
+        savestepinterval::Int = 1,
+        dt::AbstractFloat,
+        isoutside::F = ODE_DEFAULT_ISOUTOFDOMAIN,
+        save_start::Bool = true,
+        save_end::Bool = true,
+        save_everystep::Bool = true,
+        save_fields::Bool = false,
+        save_work::Bool = false,
+        maxiters::Int = 1_000_000,
+        batch_size::Int = _default_batch_size(
+            ensemblealg, trajectories
+        ),
+    ) where {N, EA <: BasicEnsembleAlgorithm, F}
+    return _solve(
+        ensemblealg, prob, alg, trajectories, dt,
+        savestepinterval, isoutside,
+        save_start, save_end, save_everystep,
+        Val(save_fields), Val(save_work),
+        maxiters, batch_size
+    )
+end
+
+function _default_batch_size(ensemblealg, trajectories)
+    if ensemblealg isa EnsembleDistributed ||
+            ensemblealg isa EnsembleSplitThreads
+        return max(1, trajectories ÷ nworkers())
+    end
+    return 1
+end
+
+function _dispatch_boris!(
+        sols, prob::TraceProblem, irange,
+        savestepinterval, dt, nt, nout, isoutside::F,
+        ::Boris, save_start, save_end,
+        save_everystep, ::Val{SaveFields}, ::Val{SaveWork}
+    ) where {SaveFields, SaveWork, F}
+    return _boris!(
+        sols, prob, irange, savestepinterval, dt, nt,
+        nout, isoutside,
+        save_start, save_end, save_everystep,
+        Val(SaveFields), Val(SaveWork)
     )
 end
 
 function _dispatch_boris!(
-        sols, prob::TraceProblem, irange, savestepinterval, dt, nt, nout, isoutside::F,
-        n, N, save_start, save_end, save_everystep, ::Val{SaveFields}, ::Val{SaveWork}
-    ) where {SaveFields, SaveWork, F}
-    return if n == 1 && N == 2
-        _boris!(
-            sols, prob, irange, savestepinterval, dt, nt, nout, isoutside,
-            save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork)
-        )
-    else
-        _multistep_boris!(
-            sols, prob, irange, savestepinterval, dt, nt, nout, isoutside, n, N,
-            save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork)
-        )
-    end
+        sols, prob::TraceProblem, irange,
+        savestepinterval, dt, nt, nout, isoutside::F,
+        alg::MultistepBoris{N}, save_start, save_end,
+        save_everystep, ::Val{SaveFields}, ::Val{SaveWork}
+    ) where {N, SaveFields, SaveWork, F}
+    return _multistep_boris!(
+        sols, prob, irange, savestepinterval, dt, nt,
+        nout, isoutside, alg.n, N,
+        save_start, save_end, save_everystep,
+        Val(SaveFields), Val(SaveWork)
+    )
 end
 
 @inline function _solve(
-        ::EnsembleSerial, prob::TraceProblem, trajectories, dt, savestepinterval,
-        isoutside::F, n, N, save_start, save_end, save_everystep,
-        ::Val{SaveFields}, ::Val{SaveWork}, maxiters, batch_size
+        ::EnsembleSerial, prob::TraceProblem,
+        alg::AbstractBoris, trajectories, dt,
+        savestepinterval, isoutside::F,
+        save_start, save_end, save_everystep,
+        ::Val{SaveFields}, ::Val{SaveWork},
+        maxiters, batch_size
     ) where {SaveFields, SaveWork, F}
     sols, nt,
         nout = _prepare(
         prob, trajectories, dt, savestepinterval,
-        save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork), maxiters
+        save_start, save_end, save_everystep,
+        Val(SaveFields), Val(SaveWork), maxiters
     )
     irange = 1:trajectories
     _dispatch_boris!(
-        sols, prob, irange, savestepinterval, dt, nt, nout, isoutside, n, N,
-        save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork)
+        sols, prob, irange, savestepinterval, dt, nt,
+        nout, isoutside, alg,
+        save_start, save_end, save_everystep,
+        Val(SaveFields), Val(SaveWork)
     )
 
     return sols
 end
 
 @inline function _solve(
-        ::EnsembleThreads, prob::TraceProblem, trajectories, dt, savestepinterval,
-        isoutside::F, n, N, save_start, save_end, save_everystep,
-        ::Val{SaveFields}, ::Val{SaveWork}, maxiters, batch_size
+        ::EnsembleThreads, prob::TraceProblem,
+        alg::AbstractBoris, trajectories, dt,
+        savestepinterval, isoutside::F,
+        save_start, save_end, save_everystep,
+        ::Val{SaveFields}, ::Val{SaveWork},
+        maxiters, batch_size
     ) where {SaveFields, SaveWork, F}
     sols, nt,
         nout = _prepare(
         prob, trajectories, dt, savestepinterval,
-        save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork), maxiters
+        save_start, save_end, save_everystep,
+        Val(SaveFields), Val(SaveWork), maxiters
     )
 
     nchunks = Threads.nthreads()
-    Threads.@threads for irange in index_chunks(1:trajectories; n = nchunks)
+    Threads.@threads for irange in index_chunks(
+            1:trajectories; n = nchunks
+        )
         _dispatch_boris!(
-            sols, prob, irange, savestepinterval, dt, nt, nout, isoutside, n, N,
-            save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork)
+            sols, prob, irange, savestepinterval,
+            dt, nt, nout, isoutside, alg,
+            save_start, save_end, save_everystep,
+            Val(SaveFields), Val(SaveWork)
         )
     end
 
@@ -229,61 +323,91 @@ The `TraceProblem` construction is a negligible struct copy relative to the
 simulation cost and the serialization overhead inherent in `pmap`.
 """
 function _solve_single_boris(
-        prob::TraceProblem, i, savestepinterval, dt, nt, nout, isoutside::F, n, N,
-        save_start, save_end, save_everystep, ::Val{SaveFields}, ::Val{SaveWork}
+        prob::TraceProblem, i, savestepinterval,
+        dt, nt, nout, isoutside::F,
+        alg::AbstractBoris,
+        save_start, save_end, save_everystep,
+        ::Val{SaveFields}, ::Val{SaveWork}
     ) where {SaveFields, SaveWork, F}
     new_prob = prob.prob_func(prob, i, false)
-    single_prob = TraceProblem(new_prob.u0, new_prob.tspan, new_prob.p)
-    sol_type = _get_sol_type(single_prob, dt, Val(SaveFields), Val(SaveWork))
+    single_prob = TraceProblem(
+        new_prob.u0, new_prob.tspan, new_prob.p
+    )
+    sol_type = _get_sol_type(
+        single_prob, dt, Val(SaveFields), Val(SaveWork)
+    )
     local_sols = Vector{sol_type}(undef, 1)
     _dispatch_boris!(
-        local_sols, single_prob, 1:1, savestepinterval, dt, nt, nout,
-        isoutside, n, N, save_start, save_end, save_everystep,
+        local_sols, single_prob, 1:1,
+        savestepinterval, dt, nt, nout,
+        isoutside, alg,
+        save_start, save_end, save_everystep,
         Val(SaveFields), Val(SaveWork)
     )
     return local_sols[1]
 end
 
 @inline function _solve(
-        ::EnsembleDistributed, prob::TraceProblem, trajectories, dt, savestepinterval,
-        isoutside::F, n, N, save_start, save_end, save_everystep,
-        ::Val{SaveFields}, ::Val{SaveWork}, maxiters, batch_size
+        ::EnsembleDistributed, prob::TraceProblem,
+        alg::AbstractBoris, trajectories, dt,
+        savestepinterval, isoutside::F,
+        save_start, save_end, save_everystep,
+        ::Val{SaveFields}, ::Val{SaveWork},
+        maxiters, batch_size
     ) where {SaveFields, SaveWork, F}
     _, nt, nout = _prepare(
         prob, trajectories, dt, savestepinterval,
-        save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork), maxiters
+        save_start, save_end, save_everystep,
+        Val(SaveFields), Val(SaveWork), maxiters
     )
-    return pmap(1:trajectories; batch_size = batch_size) do i
+    return pmap(
+        1:trajectories; batch_size = batch_size
+    ) do i
         _solve_single_boris(
-            prob, i, savestepinterval, dt, nt, nout, isoutside, n, N,
-            save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork)
+            prob, i, savestepinterval, dt, nt, nout,
+            isoutside, alg,
+            save_start, save_end, save_everystep,
+            Val(SaveFields), Val(SaveWork)
         )
     end
 end
 
 @inline function _solve(
-        ::EnsembleSplitThreads, prob::TraceProblem, trajectories, dt, savestepinterval,
-        isoutside::F, n, N, save_start, save_end, save_everystep,
-        ::Val{SaveFields}, ::Val{SaveWork}, maxiters, batch_size
+        ::EnsembleSplitThreads, prob::TraceProblem,
+        alg::AbstractBoris, trajectories, dt,
+        savestepinterval, isoutside::F,
+        save_start, save_end, save_everystep,
+        ::Val{SaveFields}, ::Val{SaveWork},
+        maxiters, batch_size
     ) where {SaveFields, SaveWork, F}
     _, nt, nout = _prepare(
         prob, trajectories, dt, savestepinterval,
-        save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork), maxiters
+        save_start, save_end, save_everystep,
+        Val(SaveFields), Val(SaveWork), maxiters
     )
-    # _solve_single_boris wraps each trajectory in a fresh TraceProblem(u0, tspan, p)
-    # with DEFAULT_PROB_FUNC. We get a sample problem from prob_func to ensure the
-    # u0 type (uType) matches.
     sample_prob = prob.prob_func(prob, 1, false)
-    dummy_prob = TraceProblem(sample_prob.u0, sample_prob.tspan, sample_prob.p)
-    sol_type = _get_sol_type(dummy_prob, dt, Val(SaveFields), Val(SaveWork))
-    ichunks = index_chunks(1:trajectories; size = batch_size)
+    dummy_prob = TraceProblem(
+        sample_prob.u0, sample_prob.tspan,
+        sample_prob.p
+    )
+    sol_type = _get_sol_type(
+        dummy_prob, dt, Val(SaveFields), Val(SaveWork)
+    )
+    ichunks = index_chunks(
+        1:trajectories; size = batch_size
+    )
     results = pmap(ichunks) do irange
-        local_sols = Vector{sol_type}(undef, length(irange))
+        local_sols = Vector{sol_type}(
+            undef, length(irange)
+        )
         Threads.@threads for k in eachindex(irange)
             i = irange[k]
             local_sols[k] = _solve_single_boris(
-                prob, i, savestepinterval, dt, nt, nout, isoutside, n, N,
-                save_start, save_end, save_everystep, Val(SaveFields), Val(SaveWork)
+                prob, i, savestepinterval,
+                dt, nt, nout, isoutside, alg,
+                save_start, save_end,
+                save_everystep,
+                Val(SaveFields), Val(SaveWork)
             )
         end
         local_sols

--- a/src/boris.jl
+++ b/src/boris.jl
@@ -10,8 +10,8 @@ The Multistep/Hyper Boris method of order `N`.
 `N` specifies the gyrophase correction order:
 2 (standard), 4, or 6 (Hyper-Boris).
 """
-struct MultistepBoris{N, T} <: AbstractBoris
-    n::T
+struct MultistepBoris{N} <: AbstractBoris
+    n::Int
 end
 
 @inline function MultistepBoris{N}(; n::Int = 1) where {N}
@@ -22,7 +22,7 @@ end
             )
         )
     end
-    return MultistepBoris{N, Int}(n)
+    return MultistepBoris{N}(n)
 end
 
 const MultistepBoris2 = MultistepBoris{2}
@@ -138,10 +138,11 @@ In-place cross product.
 end
 
 """
-    solve(prob::TraceProblem, alg::Boris,
+    solve(prob::TraceProblem,
+        alg::Union{Boris, MultistepBoris},
         ensemblealg=EnsembleSerial(); dt, kwargs...)
 
-Trace particles using the standard Boris method.
+Trace particles using the Boris or Multistep/Hyper Boris method.
 
 # Keywords
   - `trajectories::Int=1`: number of trajectories.
@@ -156,7 +157,8 @@ Trace particles using the standard Boris method.
   - `maxiters::Int=1_000_000`: maximum iterations.
 """
 @inline function solve(
-        prob::TraceProblem, alg::Boris,
+        prob::TraceProblem,
+        alg::Union{Boris, MultistepBoris},
         ensemblealg::EA = EnsembleSerial();
         trajectories::Int = 1,
         savestepinterval::Int = 1,
@@ -172,38 +174,6 @@ Trace particles using the standard Boris method.
             ensemblealg, trajectories
         ),
     ) where {EA <: BasicEnsembleAlgorithm, F}
-    return _solve(
-        ensemblealg, prob, alg, trajectories, dt,
-        savestepinterval, isoutside,
-        save_start, save_end, save_everystep,
-        Val(save_fields), Val(save_work),
-        maxiters, batch_size
-    )
-end
-
-"""
-    solve(prob::TraceProblem, alg::MultistepBoris{N},
-        ensemblealg=EnsembleSerial(); dt, kwargs...)
-
-Trace particles using the Multistep/Hyper Boris method.
-"""
-@inline function solve(
-        prob::TraceProblem, alg::MultistepBoris{N},
-        ensemblealg::EA = EnsembleSerial();
-        trajectories::Int = 1,
-        savestepinterval::Int = 1,
-        dt::AbstractFloat,
-        isoutside::F = ODE_DEFAULT_ISOUTOFDOMAIN,
-        save_start::Bool = true,
-        save_end::Bool = true,
-        save_everystep::Bool = true,
-        save_fields::Bool = false,
-        save_work::Bool = false,
-        maxiters::Int = 1_000_000,
-        batch_size::Int = _default_batch_size(
-            ensemblealg, trajectories
-        ),
-    ) where {N, EA <: BasicEnsembleAlgorithm, F}
     return _solve(
         ensemblealg, prob, alg, trajectories, dt,
         savestepinterval, isoutside,

--- a/src/boris_kernel.jl
+++ b/src/boris_kernel.jl
@@ -310,7 +310,7 @@ function _prepare_boris_solve(
 end
 
 @inbounds function solve(
-        prob::TraceProblem, backend::Backend, ::EnsembleSerial;
+        prob::TraceProblem, alg::Boris, backend::Backend, ::EnsembleSerial;
         dt::AbstractFloat, trajectories::Int = 1, savestepinterval::Int = 1,
         save_start::Bool = true, save_end::Bool = true, save_everystep::Bool = true,
         workgroup_size::Int = 256, maxiters::Int = 1_000_000
@@ -332,7 +332,7 @@ end
 end
 
 @inbounds function solve(
-        prob::TraceProblem, backend::Backend, ::EnsembleThreads;
+        prob::TraceProblem, alg::Boris, backend::Backend, ::EnsembleThreads;
         dt::AbstractFloat, trajectories::Int = 1, savestepinterval::Int = 1,
         save_start::Bool = true, save_end::Bool = true, save_everystep::Bool = true,
         workgroup_size::Int = 256, maxiters::Int = 1_000_000
@@ -366,14 +366,14 @@ end
 end
 
 @inbounds function solve(
-        prob::TraceProblem, backend::Backend,
+        prob::TraceProblem, alg::Boris, backend::Backend,
         ensemblealg::BasicEnsembleAlgorithm = EnsembleSerial();
         dt::AbstractFloat, trajectories::Int = 1, savestepinterval::Int = 1,
         save_start::Bool = true, save_end::Bool = true, save_everystep::Bool = true,
         workgroup_size::Int = 256, maxiters::Int = 1_000_000
     )
     return solve(
-        prob, backend, ensemblealg;
+        prob, alg, backend, ensemblealg;
         dt, trajectories, savestepinterval, save_start, save_end, save_everystep,
         workgroup_size, maxiters
     )

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -37,7 +37,7 @@
         )
 
         # Kernel Boris (CPU)
-        sol_kernel = solve(prob, CPU(); dt, savestepinterval = 100)
+        sol_kernel = solve(prob, Boris(), CPU(); dt, savestepinterval = 100)
 
         # Adaptive Boris
         alg_adaptive = AdaptiveBoris(safety = 0.1)
@@ -49,10 +49,10 @@
 
         # Multistep Boris
         sol_multistep = solve(
-            prob, MultistepBoris{2}(; n = 2); dt
+            prob, MultistepBoris2(; n = 2); dt
         )
         sol_multistep_sf = solve(
-            prob, MultistepBoris{2}(; n = 2);
+            prob, MultistepBoris2(; n = 2);
             dt, save_fields = true
         )
         # guiding center

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -30,8 +30,11 @@
         tspan = (0.0, 1.0)
         dt = 0.5
         prob = TraceProblem(stateinit, tspan, param)
-        sol = solve(prob; dt, savestepinterval = 100)
-        sol = solve(prob, EnsembleThreads(); dt, savestepinterval = 100)
+        sol = solve(prob, Boris(); dt, savestepinterval = 100)
+        sol = solve(
+            prob, Boris(), EnsembleThreads();
+            dt, savestepinterval = 100
+        )
 
         # Kernel Boris (CPU)
         sol_kernel = solve(prob, CPU(); dt, savestepinterval = 100)
@@ -45,8 +48,13 @@
         work = get_work(sol_adaptive)
 
         # Multistep Boris
-        sol_multistep = solve(prob; dt, n = 2)
-        sol_multistep_sf = solve(prob; dt, n = 2, save_fields = true)
+        sol_multistep = solve(
+            prob, MultistepBoris{2}(; n = 2); dt
+        )
+        sol_multistep_sf = solve(
+            prob, MultistepBoris{2}(; n = 2);
+            dt, save_fields = true
+        )
         # guiding center
         gc_init = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
         stateinit_gc, param_gc = prepare_gc(gc_init, ZeroField(), B_analytic)

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,6 +5,8 @@ Abstract type for tracing solutions.
 """
 abstract type AbstractTraceSolution{T, N, S} <: AbstractODESolution{T, N, S} end
 
+abstract type AbstractBoris end
+
 """
 Abstract type for velocity distribution functions.
 """

--- a/test/test_boris.jl
+++ b/test/test_boris.jl
@@ -46,7 +46,7 @@ using Distributed
         param = prepare(zero_E, uniform_B2, species = Electron)
         prob = TraceProblem(stateinit, tspan, param)
 
-        sol = TP.solve(prob; dt, savestepinterval = 10)[1]
+        sol = TP.solve(prob, Boris(); dt, savestepinterval = 10)[1]
 
         @test sol.u[end] ≈ [
             -0.00010199137926394769, 3.46340469171306e-5, 0.0,
@@ -63,13 +63,18 @@ using Distributed
         prob = TraceProblem(stateinit, tspan, param; prob_func = prob_func_boris_immutable)
         trajectories = 4
         savestepinterval = 1000
-        sols = TP.solve(prob, EnsembleThreads(); dt, savestepinterval, trajectories)
+        sols = TP.solve(
+            prob, Boris(), EnsembleThreads();
+            dt, savestepinterval, trajectories
+        )
         @test sum(s -> sum(s.u[end][4]), sols) ≈ -608930.4382490724
 
         prob = TraceProblem(stateinit, tspan, param; prob_func = prob_func_boris_immutable)
         trajectories = 2
         savestepinterval = 1000
-        sols = TP.solve(prob; dt, savestepinterval, trajectories)
+        sols = TP.solve(
+            prob, Boris(); dt, savestepinterval, trajectories
+        )
         @test sum(s -> sum(s.u[end]), sols) ≈ -420646.2195768674
 
         x0 = [-1.0, 0.0, 0.0]
@@ -79,7 +84,7 @@ using Distributed
         dt = 1.0e-4
         param = prepare(zero_E, time_varying_B, species = Electron)
         prob = TraceProblem(stateinit, tspan, param)
-        sol = TP.solve(prob; dt, savestepinterval = 100)[1]
+        sol = TP.solve(prob, Boris(); dt, savestepinterval = 100)[1]
         @test sol[1, end] ≈ -512.8807214528281
 
         new_tspan = (0.0, 2.0e-8)
@@ -105,10 +110,12 @@ using Distributed
         prob = TP.TraceProblem(u0, tspan, param)
 
         # Solve with standard Boris (n=1 by default)
-        sol_std = TP.solve(prob; dt)
+        sol_std = TP.solve(prob, Boris(); dt)
 
         # 2-step
-        sol_multi_2 = TP.solve(prob; dt, n = 2)
+        sol_multi_2 = TP.solve(
+            prob, MultistepBoris{2}(; n = 2); dt
+        )
 
         @test sol_std[1].u[end][1] ≈ 10.0 atol = 1.0e-6
         @test sol_multi_2[1].u[end][1] ≈ 10.0 atol = 1.0e-6
@@ -128,9 +135,15 @@ using Distributed
 
         prob_gyro = TP.TraceProblem(u0_gyro, (0.0, 2π), param_gyro)
 
-        sol_1step_gyro = TP.solve(prob_gyro; dt = 0.1, n = 1)
-        sol_2step_gyro = TP.solve(prob_gyro; dt = 0.1, n = 2)
-        sol_4step_gyro = TP.solve(prob_gyro; dt = 0.1, n = 4)
+        sol_1step_gyro = TP.solve(
+            prob_gyro, Boris(); dt = 0.1
+        )
+        sol_2step_gyro = TP.solve(
+            prob_gyro, MultistepBoris{2}(; n = 2); dt = 0.1
+        )
+        sol_4step_gyro = TP.solve(
+            prob_gyro, MultistepBoris{2}(; n = 4); dt = 0.1
+        )
 
         # After one period, should return to origin
         @test hypot(@views sol_1step_gyro[1].u[end][1:3]...) < 0.02
@@ -156,9 +169,15 @@ using Distributed
         prob = TP.TraceProblem(u0, tspan, param)
 
         # 2-step Hyper Boris (N=4, N=6)
-        sol_hyper_4 = TP.solve(prob; dt, n = 2, N = 4)
-        sol_hyper_6 = TP.solve(prob; dt, n = 2, N = 6)
-        sol_hyper_single = TP.solve(prob; dt, n = 1, N = 4)
+        sol_hyper_4 = TP.solve(
+            prob, MultistepBoris{4}(; n = 2); dt
+        )
+        sol_hyper_6 = TP.solve(
+            prob, MultistepBoris{6}(; n = 2); dt
+        )
+        sol_hyper_single = TP.solve(
+            prob, MultistepBoris{4}(; n = 1); dt
+        )
 
         @test sol_hyper_4[1].u[end][1] ≈ 10.0 atol = 1.0e-6
         @test sol_hyper_6[1].u[end][1] ≈ 10.0 atol = 1.0e-6
@@ -173,8 +192,12 @@ using Distributed
         u0_gyro = SA[0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
         prob_gyro = TP.TraceProblem(u0_gyro, (0.0, 2π), param_gyro)
 
-        sol_hyper_4_gyro = TP.solve(prob_gyro; dt = 0.1, n = 4, N = 4)
-        sol_hyper_6_gyro = TP.solve(prob_gyro; dt = 0.1, n = 4, N = 6)
+        sol_hyper_4_gyro = TP.solve(
+            prob_gyro, MultistepBoris{4}(; n = 4); dt = 0.1
+        )
+        sol_hyper_6_gyro = TP.solve(
+            prob_gyro, MultistepBoris{6}(; n = 4); dt = 0.1
+        )
 
         @test hypot(@views sol_hyper_4_gyro[1].u[end][1:3]...) < 0.02
         @test hypot(@views sol_hyper_6_gyro[1].u[end][1:3]...) < 0.02
@@ -238,7 +261,7 @@ using Distributed
         prob = TraceProblem(u0, tspan, param)
 
         # Standard Boris
-        sol_boris = TP.solve(prob; dt = dt)[1]
+        sol_boris = TP.solve(prob, Boris(); dt = dt)[1]
         # If B was 0.01, vx should have changed significantly
         @test abs(sol_boris.u[end][4]) < 1.0e5 - 100
 
@@ -264,23 +287,27 @@ using Distributed
         # savestepinterval = 10
         # nt = 1000. steps = 1000/10 = 100.
         # nout = 101 (0, 10, ..., 1000)
-        sol = TP.solve(prob; dt = dt, savestepinterval = 10)[1]
+        sol = TP.solve(
+            prob, Boris(); dt = dt, savestepinterval = 10
+        )[1]
         @test length(sol) == 101
         @test sol.t[1] == tspan[1]
         @test sol.t[end] == tspan[2]
 
         # Scenario 2: Only final state
         sol = TP.solve(
-            prob; dt = dt, savestepinterval = 10,
-            save_everystep = false, save_start = false, save_end = true
+            prob, Boris(); dt = dt, savestepinterval = 10,
+            save_everystep = false, save_start = false,
+            save_end = true
         )[1]
         @test length(sol) == 1
         @test sol.t[1] == tspan[2]
 
         # Scenario 3: Start and End
         sol = TP.solve(
-            prob; dt = dt, savestepinterval = 10,
-            save_everystep = false, save_start = true, save_end = true
+            prob, Boris(); dt = dt, savestepinterval = 10,
+            save_everystep = false, save_start = true,
+            save_end = true
         )[1]
         @test length(sol) == 2
         @test sol.t[1] == tspan[1]
@@ -288,15 +315,17 @@ using Distributed
 
         # Scenario 4: Only start
         sol = TP.solve(
-            prob; dt = dt, savestepinterval = 10,
-            save_everystep = false, save_start = true, save_end = false
+            prob, Boris(); dt = dt, savestepinterval = 10,
+            save_everystep = false, save_start = true,
+            save_end = false
         )[1]
         @test length(sol) == 1
         @test sol.t[1] == tspan[1]
 
         # Scenario 5: Every step but no start/end
         sol = TP.solve(
-            prob; dt = dt, savestepinterval = 10, save_everystep = true,
+            prob, Boris(); dt = dt, savestepinterval = 10,
+            save_everystep = true,
             save_start = false, save_end = false
         )[1]
         # Steps: 10, 20, ..., 990.
@@ -306,8 +335,9 @@ using Distributed
 
         # Scenario 6: Irregular interval
         sol = TP.solve(
-            prob; dt = dt, savestepinterval = 3,
-            save_everystep = true, save_start = true, save_end = true
+            prob, Boris(); dt = dt, savestepinterval = 3,
+            save_everystep = true, save_start = true,
+            save_end = true
         )[1]
         @test length(sol) == 335
         @test sol.t[1] == tspan[1]
@@ -317,15 +347,20 @@ using Distributed
 
         # Multistep Boris test
         sol_ms = TP.solve(
-            prob; dt = dt, savestepinterval = 10, n = 2,
-            save_everystep = false, save_start = true, save_end = true
+            prob, MultistepBoris{2}(; n = 2);
+            dt = dt, savestepinterval = 10,
+            save_everystep = false, save_start = true,
+            save_end = true
         )[1]
         @test length(sol_ms) == 2
         @test sol_ms.t[1] == tspan[1]
         @test sol_ms.t[end] == tspan[2]
 
         # Save fields test
-        sol_fields = TP.solve(prob; dt, savestepinterval = 10, save_fields = true)[1]
+        sol_fields = TP.solve(
+            prob, Boris();
+            dt, savestepinterval = 10, save_fields = true
+        )[1]
         # Check dimensions of the state vector (not the solution object length)
         @test length(sol_fields.u[1]) == 12
         # Check field values. E=0, B=[0,0,0.01].
@@ -356,7 +391,11 @@ using Distributed
         prob = TraceProblem(stateinit, tspan, param)
 
         # Test save_work=true
-        sol = TP.solve(prob; dt, savestepinterval = 1, save_work = true, save_everystep = true)[1]
+        sol = TP.solve(
+            prob, Boris();
+            dt, savestepinterval = 1,
+            save_work = true, save_everystep = true
+        )[1]
 
         # Dimension check: 6 (state) + 4 (work) = 10
         @test length(sol.u[1]) == 10
@@ -386,13 +425,20 @@ using Distributed
         param_beta = prepare(zero_E, time_varying_B_linear, species = Electron)
         prob_beta = TraceProblem(stateinit, tspan, param_beta)
 
-        sol_beta = TP.solve(prob_beta; dt, savestepinterval = 1, save_work = true)[1]
+        sol_beta = TP.solve(
+            prob_beta, Boris();
+            dt, savestepinterval = 1, save_work = true
+        )[1]
 
         work_beta = sol_beta.u[1][7:10]
         @test work_beta[4] > 0.0 # P_betatron should be positive
 
         # Test with save_fields=true AND save_work=true
-        sol_both = TP.solve(prob; dt, savestepinterval = 1, save_fields = true, save_work = true)[1]
+        sol_both = TP.solve(
+            prob, Boris();
+            dt, savestepinterval = 1,
+            save_fields = true, save_work = true
+        )[1]
         # Dim: 6 + 6 + 4 = 16
         @test length(sol_both.u[1]) == 16
         # E, B at 7-12
@@ -400,7 +446,10 @@ using Distributed
         @test sol_both.u[1][13:16] == sol.u[1][7:10]
 
         # Test Multistep Boris with save_work
-        sol_ms = TP.solve(prob; dt, n = 2, save_work = true, savestepinterval = 1)[1]
+        sol_ms = TP.solve(
+            prob, MultistepBoris{2}(; n = 2);
+            dt, save_work = true, savestepinterval = 1
+        )[1]
         @test length(sol_ms.u[1]) == 10
         work_ms = sol_ms.u[1][7:10]
         @test work_ms[1] ≈ 0.0 atol = 1.0e-10
@@ -409,7 +458,10 @@ using Distributed
         # Test Adaptive Boris with save_work
         # Use simple AdaptiveBoris
         alg_adaptive = AdaptiveBoris(safety = 0.1)
-        sol_adaptive = TP.solve(prob, alg_adaptive; save_work = true, save_everystep = true)[1]
+        sol_adaptive = TP.solve(
+            prob, alg_adaptive;
+            save_work = true, save_everystep = true
+        )[1]
         @test length(sol_adaptive.u[1]) == 10
         work_adaptive = sol_adaptive.u[1][7:10]
         @test work_adaptive[1] ≈ 0.0 atol = 1.0e-10
@@ -427,10 +479,16 @@ using Distributed
         prob = TraceProblem(stateinit, tspan, param)
 
         # Reference solution with saved data
-        sol_ref = TP.solve(prob; dt, savestepinterval = 1, save_fields = true, save_work = true)[1]
+        sol_ref = TP.solve(
+            prob, Boris();
+            dt, savestepinterval = 1,
+            save_fields = true, save_work = true
+        )[1]
 
         # Solution without saved data
-        sol = TP.solve(prob; dt, savestepinterval = 1)[1]
+        sol = TP.solve(
+            prob, Boris(); dt, savestepinterval = 1
+        )[1]
 
         # Post-process
         E_post, B_post = get_fields(sol)
@@ -458,15 +516,19 @@ using Distributed
         prob = TraceProblem(stateinit, tspan, param)
 
         # maxiters limit (nt = 100)
-        @test_throws ArgumentError TP.solve(prob; dt, maxiters = 50)
+        @test_throws ArgumentError TP.solve(
+            prob, Boris(); dt, maxiters = 50
+        )
 
         # min_dt limit
         dt_too_small = eps(Float64)
-        @test_throws ArgumentError TP.solve(prob; dt = dt_too_small)
+        @test_throws ArgumentError TP.solve(
+            prob, Boris(); dt = dt_too_small
+        )
 
         # Hyper Boris N parameter limit
-        @test_throws ArgumentError TP.solve(prob; dt, N = 1)
-        @test_throws ArgumentError TP.solve(prob; dt, n = 2, N = 3)
+        @test_throws ArgumentError MultistepBoris{1}()
+        @test_throws ArgumentError MultistepBoris{3}(; n = 2)
     end
 
     @testset "EnsembleDistributed" begin
@@ -500,11 +562,14 @@ using Distributed
             savestepinterval = 1000
 
             sols_serial = TP.solve(
-                prob_dist, EnsembleSerial(); dt, savestepinterval, trajectories
+                prob_dist, Boris(), EnsembleSerial();
+                dt, savestepinterval, trajectories
             )
             @testset "Boris" begin
                 sols_dist = TP.solve(
-                    prob_dist, EnsembleDistributed(); dt, savestepinterval, trajectories
+                    prob_dist, Boris(),
+                    EnsembleDistributed();
+                    dt, savestepinterval, trajectories
                 )
 
                 @test length(sols_dist) == trajectories
@@ -514,7 +579,9 @@ using Distributed
             end
             @testset "SplitThreads" begin
                 sols_split = TP.solve(
-                    prob_dist, EnsembleSplitThreads(); dt, savestepinterval, trajectories
+                    prob_dist, Boris(),
+                    EnsembleSplitThreads();
+                    dt, savestepinterval, trajectories
                 )
 
                 @test length(sols_split) == trajectories

--- a/test/test_boris_kernel.jl
+++ b/test/test_boris_kernel.jl
@@ -138,11 +138,11 @@ const KA = KernelAbstractions
         backend = CPU()
 
         # maxiters limit (nt = 1000)
-        @test_throws ArgumentError TP.solve(prob, backend; dt, maxiters = 500)
+        @test_throws ArgumentError TP.solve(prob, Boris(), backend; dt, maxiters = 500)
 
         # min_dt limit
         dt_too_small = eps(Float64)
-        @test_throws ArgumentError TP.solve(prob, backend; dt = dt_too_small)
+        @test_throws ArgumentError TP.solve(prob, Boris(), backend; dt = dt_too_small)
     end
 end
 

--- a/test/test_boris_kernel.jl
+++ b/test/test_boris_kernel.jl
@@ -82,7 +82,7 @@ const KA = KernelAbstractions
         backend = CPU()
 
         sol_gpu = TP.solve(prob, backend; dt, trajectories = 1, savestepinterval = 10)
-        sol_cpu = TP.solve(prob; dt, savestepinterval = 10)
+        sol_cpu = TP.solve(prob, Boris(); dt, savestepinterval = 10)
 
         @test length(sol_gpu[1].t) == length(sol_cpu[1].t)
 

--- a/test/test_boris_kernel.jl
+++ b/test/test_boris_kernel.jl
@@ -24,7 +24,7 @@ const KA = KernelAbstractions
     @testset "CPU Backend" begin
         backend = CPU()
 
-        sol_gpu = TP.solve(prob, backend; dt, trajectories = 1, savestepinterval = 10)
+        sol_gpu = TP.solve(prob, Boris(), backend; dt, trajectories = 1, savestepinterval = 10)
 
         @test length(sol_gpu) == 1
         @test length(sol_gpu[1].t) > 0
@@ -46,7 +46,7 @@ const KA = KernelAbstractions
         )
         prob_multi = TraceProblem(stateinit, tspan, param; prob_func = prob_func_gpu)
 
-        sols_gpu = TP.solve(prob_multi, backend; dt, trajectories = 5, savestepinterval = 100)
+        sols_gpu = TP.solve(prob_multi, Boris(), backend; dt, trajectories = 5, savestepinterval = 100)
 
         @test length(sols_gpu) == 5
 
@@ -66,11 +66,11 @@ const KA = KernelAbstractions
 
         trajectories = 10
         sols_serial = TP.solve(
-            prob_multi, backend, EnsembleSerial();
+            prob_multi, Boris(), backend, EnsembleSerial();
             dt, trajectories, savestepinterval = 100
         )
         sols_threads = TP.solve(
-            prob_multi, backend, EnsembleThreads();
+            prob_multi, Boris(), backend, EnsembleThreads();
             dt, trajectories, savestepinterval = 100
         )
 
@@ -81,7 +81,7 @@ const KA = KernelAbstractions
     @testset "Kernel vs Native Solver Equivalence" begin
         backend = CPU()
 
-        sol_gpu = TP.solve(prob, backend; dt, trajectories = 1, savestepinterval = 10)
+        sol_gpu = TP.solve(prob, Boris(), backend; dt, trajectories = 1, savestepinterval = 10)
         sol_cpu = TP.solve(prob, Boris(); dt, savestepinterval = 10)
 
         @test length(sol_gpu[1].t) == length(sol_cpu[1].t)
@@ -105,7 +105,7 @@ const KA = KernelAbstractions
         dt_gyro = gyroperiod / 100
 
         prob_gyro = TraceProblem(stateinit, tspan_gyro, param)
-        sol_gyro = TP.solve(prob_gyro, backend; dt = dt_gyro, savestepinterval = 10)
+        sol_gyro = TP.solve(prob_gyro, Boris(), backend; dt = dt_gyro, savestepinterval = 10)
 
         # Check energy conservation at the final step to reduce test count
         vx = sol_gyro[1].u[end][4]
@@ -119,7 +119,7 @@ const KA = KernelAbstractions
         backend = CPU()
 
         sol_start_end = TP.solve(
-            prob, backend; dt, trajectories = 1,
+            prob, Boris(), backend; dt, trajectories = 1,
             save_everystep = false, save_start = true, save_end = true
         )
         @test length(sol_start_end[1].t) == 2
@@ -127,7 +127,7 @@ const KA = KernelAbstractions
         @test sol_start_end[1].t[end] == tspan[2]
 
         sol_end_only = TP.solve(
-            prob, backend; dt, trajectories = 1,
+            prob, Boris(), backend; dt, trajectories = 1,
             save_everystep = false, save_start = false, save_end = true
         )
         @test length(sol_end_only[1].t) == 1

--- a/test/test_boundary.jl
+++ b/test/test_boundary.jl
@@ -35,7 +35,10 @@ using OrdinaryDiffEq: ReturnCode
 
         @testset "Boris" begin
             prob = TraceProblem(u0, tspan, p)
-            sol = TP.solve(prob, dt = 0.2; isoutside = callback.condition)[1]
+            sol = TP.solve(
+                prob, Boris(), dt = 0.2;
+                isoutside = callback.condition
+            )[1]
 
             @test !any(isnan, sol.u[end])
             @test norm(sol.u[end][1:3]) <= 1.0
@@ -99,7 +102,7 @@ using OrdinaryDiffEq: ReturnCode
             u0 = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
             tspan = (0, 10)
             prob = TraceProblem(u0, tspan, param)
-            sol = TP.solve(prob; dt = 1.0)[1]
+            sol = TP.solve(prob, Boris(); dt = 1.0)[1]
             @test sol.t[end] == 10
             @test sol.retcode == ReturnCode.Success
         end


### PR DESCRIPTION
# Walkthrough: Boris Solver Refactoring

## Summary

Refactored the Boris particle pusher API from keyword-based algorithm selection
(`solve(prob; dt, n=2, N=4)`) to OrdinaryDiffEq-style solver structs
(`solve(prob, MultistepBoris{4}(; n=2); dt)`).

## Type Hierarchy

```
AbstractBoris
├── Boris                       # standard Boris (fixed dt)
├── MultistepBoris{N}        # N ∈ {2, 4, 6}, n subcycles
└── AdaptiveBoris            # adaptive time stepping (unchanged)
```

Convenience aliases: `MultistepBoris2`, `MultistepBoris4`, `MultistepBoris6`.

## API Changes

| Before | After |
|--------|-------|
| `solve(prob; dt)` | `solve(prob, Boris(); dt)` |
| `solve(prob; dt, n=2)` | `solve(prob, MultistepBoris{2}(; n=2); dt)` |
| `solve(prob; dt, n=2, N=4)` | `solve(prob, MultistepBoris{4}(; n=2); dt)` |
| `solve(prob, EnsembleThreads(); dt)` | `solve(prob, Boris(), EnsembleThreads(); dt)` |
| `solve(prob, AdaptiveBoris(...))` | unchanged |

## Files Modified

### Source

- [types.jl](file:///c:/Users/hyzhou/Documents/GitHub/TestParticle.jl/src/types.jl) — Added `abstract type AbstractBoris end`
- [boris.jl](file:///c:/Users/hyzhou/Documents/GitHub/TestParticle.jl/src/boris.jl) — Added `Boris`, `MultistepBoris{N,T}` structs; refactored `solve`, `_solve`, `_dispatch_boris!`, `_solve_single_boris` to accept `alg::AbstractBoris` instead of `n::Int, N::Int`; extracted `_default_batch_size` helper
- [adaptive_boris.jl](file:///c:/Users/hyzhou/Documents/GitHub/TestParticle.jl/src/adaptive_boris.jl) — Changed `AdaptiveBoris{T}` to subtype `AbstractBoris`
- [TestParticle.jl](file:///c:/Users/hyzhou/Documents/GitHub/TestParticle.jl/src/TestParticle.jl) — Added `Boris`, `MultistepBoris`, `MultistepBoris2/4/6` to exports
- [precompile.jl](file:///c:/Users/hyzhou/Documents/GitHub/TestParticle.jl/src/precompile.jl) — Updated workloads

### Tests

- [test_boris.jl](file:///c:/Users/hyzhou/Documents/GitHub/TestParticle.jl/test/test_boris.jl) — All 99 tests updated, passing
- [test_boundary.jl](file:///c:/Users/hyzhou/Documents/GitHub/TestParticle.jl/test/test_boundary.jl) — Updated Boris calls, 19/19 passing
- [test_boris_kernel.jl](file:///c:/Users/hyzhou/Documents/GitHub/TestParticle.jl/test/test_boris_kernel.jl) — Updated equivalence test, 30/30 passing

## Test Results

| Test Suite | Result |
|------------|--------|
| Boris Solvers | 99/99 ✅ |
| Callbacks and Termination | 19/19 ✅ |
| Boris Kernel Solver | 30/30 ✅ |
| Adaptive Hybrid Solver | 5/5 ✅ |
