### PR TITLE
utility: avoid generic types of Any in zero.jl

### DIFF
--- a/src/utility/zero.jl
+++ b/src/utility/zero.jl
@@ -20,11 +20,10 @@ struct ZeroVector end
 
 # Make ZeroVector work with array assignment
 Base.setindex!(A::AbstractArray, ::ZeroVector, I...) = fill!(view(A, I...), zero(eltype(A)))
-Base.setindex!(A::Array{Any}, z::ZeroVector, i::Int) =
-    invoke(Base.setindex!, Tuple{Array{Any}, Any, Int}, A, z, i)
 
-function Base.setindex!(A::Array, ::ZeroVector, i::Int)
-    return A[i] = zero(eltype(A))
+function Base.setindex!(A::Array{T}, z::ZeroVector, i::Int) where {T}
+    isconcretetype(T) && return A[i] = zero(T)
+    return invoke(Base.setindex!, Tuple{Array, Any, Int}, A, z, i)
 end
 
 Base.getindex(::ZeroVector, I...) = 0


### PR DESCRIPTION
Refactored `Base.setindex!` for `ZeroVector` in `src/utility/zero.jl` to use
a generic type parameter `T` instead of explicit `Array{Any}` dispatch.
This follows the project guideline to avoid `Any` types in signatures
and improves code robustness by handling concrete and non-concrete
array types through a single method with an `isconcretetype(T)` check.
The `Any` case is now handled via `invoke` to the base implementation.

Co-authored-by: henry2004y <20110816+henry2004y@users.noreply.github.com>